### PR TITLE
Make MessageResponse and DynamicContent Encodable

### DIFF
--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// [Message Response](https://docs.anthropic.com/claude/reference/messages_post)
-public struct MessageResponse: Decodable {
+public struct MessageResponse: Codable {
    
    /// Unique object identifier.
    ///
@@ -82,7 +82,7 @@ public struct MessageResponse: Decodable {
    /// Container for the number of tokens used.
    public let usage: Usage
    
-   public enum Content: Decodable {
+   public enum Content: Codable {
       
       public typealias Input = [String: DynamicContent]
       
@@ -93,7 +93,7 @@ public struct MessageResponse: Decodable {
          case type, text, id, name, input
       }
       
-      public enum DynamicContent: Decodable, Encodable {
+      public enum DynamicContent: Codable {
 
          case string(String)
          case integer(Int)
@@ -161,10 +161,24 @@ public struct MessageResponse: Decodable {
             throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Invalid type value found in JSON!")
          }
       }
+
+       public func encode(to encoder: any Encoder) throws {
+           var container = try encoder.container(keyedBy: CodingKeys.self)
+           switch self {
+           case .text(let text):
+               try container.encode("text", forKey: .type)
+               try container.encode(text, forKey: .text)
+           case .toolUse(let id, let name, let input):
+               try container.encode("tool_use", forKey: .type)
+               try container.encode(id, forKey: .id)
+               try container.encode(name, forKey: .name)
+               try container.encode(input, forKey: .input)
+           }
+       }
    }
    
-   public struct Usage: Decodable {
-      
+   public struct Usage: Codable {
+
       /// The number of input tokens which were used.
       public let inputTokens: Int
       

--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
@@ -88,13 +88,13 @@ public struct MessageResponse: Decodable {
       
       case text(String)
       case toolUse(id: String, name: String, input: Input)
-      
+
       private enum CodingKeys: String, CodingKey {
          case type, text, id, name, input
       }
       
-      public enum DynamicContent: Decodable {
-         
+      public enum DynamicContent: Decodable, Encodable {
+
          case string(String)
          case integer(Int)
          case double(Double)
@@ -102,7 +102,7 @@ public struct MessageResponse: Decodable {
          case array([DynamicContent])
          case bool(Bool)
          case null
-         
+
          public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
             if let intValue = try? container.decode(Int.self) {
@@ -123,6 +123,26 @@ public struct MessageResponse: Decodable {
                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Content cannot be decoded")
             }
          }
+
+          public func encode(to encoder: any Encoder) throws {
+              var container = encoder.singleValueContainer()
+              switch self {
+              case .string(let val):
+                  try container.encode(val)
+              case .integer(let val):
+                  try container.encode(val)
+              case .double(let val):
+                  try container.encode(val)
+              case .dictionary(let val):
+                  try container.encode(val)
+              case .array(let val):
+                  try container.encode(val)
+              case .bool(let val):
+                  try container.encode(val)
+              case .null:
+                  try container.encodeNil()
+              }
+          }
       }
 
       public init(from decoder: Decoder) throws {


### PR DESCRIPTION
eWe've been using this library in a new app but haven't been able to work with DynamicContent directly in a way that works for us. What did work is taking DynamicContent and turning it back into raw JSON data, then parsing it back into a more specific type.

This PR started by simply implementing the Encodable protocol for DynamicContent so this is possible.

We also found that we wanted access to the raw response from Anthropic in string or JSON format for error logging purposes, so making all of MessageResponse encodable enabled that as well.