### PR TITLE
FIX: make `inputTokens` optional as it might be null in the event `message_delta`

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ public struct MessageResponse: Decodable {
    public struct Usage: Decodable {
       
       /// The number of input tokens which were used.
-      public let inputTokens: Int
+      public let inputTokens: Int?
       
       /// The number of output tokens which were used.
       public let outputTokens: Int

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ public struct MessageResponse: Decodable {
    public struct Usage: Decodable {
       
       /// The number of input tokens which were used.
-      public let inputTokens: Int
+      public let inputTokens: Int?
       
       /// The number of output tokens which were used.
       public let outputTokens: Int
@@ -598,6 +598,9 @@ public struct MessageStreamResponse: Decodable {
    
    /// Available in "content_block_delta", "message_delta" events.
    public let delta: Delta?
+   
+   /// Available in "message_delta" events.
+   public let usage: MessageResponse.Usage?
    
    public struct Delta: Decodable {
       

--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
@@ -182,7 +182,7 @@ public struct MessageResponse: Decodable {
    
    public struct Usage: Codable {
       /// The number of input tokens which were used.
-      public let inputTokens: Int
+      public let inputTokens: Int?
       
       /// The number of output tokens which were used.
       public let outputTokens: Int

--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageStreamResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageStreamResponse.swift
@@ -33,6 +33,9 @@ public struct MessageStreamResponse: Decodable {
    
    /// Available in "content_block_delta", "message_delta" events.
    public let delta: Delta?
+    
+   /// Available in "message_delta" events.
+   public let usage: MessageResponse.Usage?
    
    public var streamEvent: StreamEvent? {
       StreamEvent(rawValue: type)


### PR DESCRIPTION
### Overview

FIX: make `inputTokens` optional as it might be null in the event `message_delta`