### PR TITLE
Add AIProxy support

### DIFF
--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0DCD68B32C5B049A00CFDE84 /* ServiceSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCD68B22C5B049A00CFDE84 /* ServiceSelectionView.swift */; };
+		0DCD68B52C5B057000CFDE84 /* AIProxyIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCD68B42C5B057000CFDE84 /* AIProxyIntroView.swift */; };
 		7B3287D32B8B1260002C7FEF /* SwiftAnthropicExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3287D22B8B1260002C7FEF /* SwiftAnthropicExampleApp.swift */; };
 		7B3287D72B8B1261002C7FEF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B3287D62B8B1261002C7FEF /* Assets.xcassets */; };
 		7B3287DA2B8B1261002C7FEF /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B3287D92B8B1261002C7FEF /* Preview Assets.xcassets */; };
@@ -41,6 +43,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0DCD68B22C5B049A00CFDE84 /* ServiceSelectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceSelectionView.swift; sourceTree = "<group>"; };
+		0DCD68B42C5B057000CFDE84 /* AIProxyIntroView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AIProxyIntroView.swift; sourceTree = "<group>"; };
 		7B3287CF2B8B1260002C7FEF /* SwiftAnthropicExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftAnthropicExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B3287D22B8B1260002C7FEF /* SwiftAnthropicExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftAnthropicExampleApp.swift; sourceTree = "<group>"; };
 		7B3287D62B8B1261002C7FEF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -108,6 +112,8 @@
 		7B3287D12B8B1260002C7FEF /* SwiftAnthropicExample */ = {
 			isa = PBXGroup;
 			children = (
+				0DCD68B22C5B049A00CFDE84 /* ServiceSelectionView.swift */,
+				0DCD68B42C5B057000CFDE84 /* AIProxyIntroView.swift */,
 				7B3287D22B8B1260002C7FEF /* SwiftAnthropicExampleApp.swift */,
 				7B3288032B8B14A3002C7FEF /* ApiKeyIntroView.swift */,
 				7B3288052B8B1530002C7FEF /* OptionsListView.swift */,
@@ -307,6 +313,8 @@
 				7B32880A2B8B17A1002C7FEF /* MessageDemoObservable.swift in Sources */,
 				7BF304E02BBFBE1000671273 /* MessageFunctionCallingDemoView.swift in Sources */,
 				7B3288062B8B1530002C7FEF /* OptionsListView.swift in Sources */,
+				0DCD68B52C5B057000CFDE84 /* AIProxyIntroView.swift in Sources */,
+				0DCD68B32C5B049A00CFDE84 /* ServiceSelectionView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/AIProxyIntroView.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/AIProxyIntroView.swift
@@ -1,0 +1,65 @@
+//
+//  AIProxyIntroView.swift
+//  SwiftAnthropicExample
+//
+//  Created by Lou Zell on 7/31/24.
+//
+
+import SwiftUI
+import SwiftAnthropic
+
+struct AIProxyIntroView: View {
+
+   @State private var partialKey = ""
+   @State private var serviceURL = ""
+
+   private var canProceed: Bool {
+      return !(self.partialKey.isEmpty || self.serviceURL.isEmpty)
+   }
+
+   var body: some View {
+      NavigationStack {
+         VStack {
+            Spacer()
+            VStack(spacing: 24) {
+               TextField("Enter partial key", text: $partialKey)
+               TextField("Enter your service's URL", text: $serviceURL)
+            }
+            .padding()
+            .textFieldStyle(.roundedBorder)
+
+            Text("You receive a partial key and service URL when you configure an app in the AIProxy dashboard")
+               .font(.caption)
+
+            NavigationLink(destination: OptionsListView(service: aiproxyService)) {
+               Text("Continue")
+                  .padding()
+                  .padding(.horizontal, 48)
+                  .foregroundColor(.white)
+                  .background(
+                     Capsule()
+                        .foregroundColor(canProceed ? Color(red: 186/255, green: 91/255, blue: 55/255) : .gray.opacity(0.2)))
+            }
+            .disabled(!canProceed)
+            Spacer()
+            Group {
+               Text("AIProxy keeps your Anthropic API key secure. To configure AIProxy for your project, or to learn more about how it works, please see the docs at ") + Text("[this link](https://www.aiproxy.pro/docs).")
+            }
+            .font(.caption)
+         }
+         .padding()
+         .navigationTitle("AIProxy Configuration")
+      }
+   }
+
+   private var aiproxyService: AnthropicService {
+      return AnthropicServiceFactory.service(
+         aiproxyPartialKey: partialKey,
+         aiproxyServiceURL: serviceURL
+      )
+   }
+}
+
+#Preview {
+   ApiKeyIntroView()
+}

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/ServiceSelectionView.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/ServiceSelectionView.swift
@@ -1,0 +1,47 @@
+//
+//  ServiceSelectionView.swift
+//  SwiftAnthropicExample
+//
+//  Created by Lou Zell on 7/31/24.
+//
+
+import SwiftUI
+
+struct ServiceSelectionView: View {
+
+   var body: some View {
+      NavigationStack {
+         List {
+            Section("Select Service") {
+               NavigationLink(destination: ApiKeyIntroView()) {
+                  VStack(alignment: .leading) {
+                     Text("Default Anthropic Service")
+                        .padding(.bottom, 10)
+                     Group {
+                        Text("Use this service to test Anthropic functionality by providing your own Anthropic key.")
+                     }
+                     .font(.caption)
+                     .fontWeight(.light)
+                  }
+               }
+
+               NavigationLink(destination: AIProxyIntroView()) {
+                  VStack(alignment: .leading) {
+                     Text("AIProxy Service")
+                        .padding(.bottom, 10)
+                     Group {
+                        Text("Use this service to test Anthropic functionality with requests proxied through AIProxy for key protection.")
+                     }
+                     .font(.caption)
+                     .fontWeight(.light)
+                  }
+               }
+            }
+         }
+      }
+   }
+}
+
+#Preview {
+   ServiceSelectionView()
+}

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/SwiftAnthropicExampleApp.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/SwiftAnthropicExampleApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SwiftAnthropicExampleApp: App {
     var body: some Scene {
         WindowGroup {
-           ApiKeyIntroView()
+           ServiceSelectionView()
         }
     }
 }

--- a/Sources/Anthropic/AIProxy/AIProxyCertificatePinning.swift
+++ b/Sources/Anthropic/AIProxy/AIProxyCertificatePinning.swift
@@ -1,0 +1,181 @@
+//
+//  AIProxyCertificatePinning.swift
+//
+//
+//  Created by Lou Zell on 6/23/24.
+//
+
+import Foundation
+import OSLog
+
+private let aiproxyLogger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "UnknownApp",
+                                   category: "SwiftAnthropic+AIProxyCertificatePinning")
+
+/// ## About
+/// Use this class in conjunction with a URLSession to adopt certificate pinning in your app.
+/// Cert pinning greatly reduces the ability for an attacker to snoop on your traffic.
+///
+/// A common misunderstanding about https is that it's hard for an attacker to read your traffic.
+/// Unfortunately, that is only true if you, as the developer, control both sides of the pipe.
+/// As an app developer, this is almost never the case. You ship your apps to the app store, and
+/// attackers install them. When an attacker has your app on hardware they control (e.g. an iPhone),
+/// it is trivial for them to MITM your app and read encrypted traffic.
+///
+/// Certificate pinning adds an additional layer of security by only allowing the TLS handshake to
+/// succeed if your app recognizes the public key from the other side. I have baked in several AIProxy
+/// public keys to this implementation.
+///
+/// This also functions as a reference implementation for any other libraries that want to interact
+/// with the aiproxy.pro service using certificate pinning.
+///
+/// ## Implementor's note, and a gotcha
+/// Use an instance of this class as the delegate to URLSession. For example:
+///
+///     let mySession = URLSession(
+///        configuration: .default,
+///        delegate: AIProxyCertificatePinningDelegate(),
+///        delegateQueue: nil
+///     )
+///
+/// In a perfect world, this would be all that is required of you. In fact, it is all that is required to protect requests made
+/// with `await mySession.data(for:)`, because Foundation calls `urlSession:didReceiveChallenge:`
+/// internally. However, `await mySession.bytes(for:)` is not protected, which is rather odd. As a workaround,
+/// change your callsites from:
+///
+///     await mySession.bytes(for: request)
+///
+/// to:
+///
+///     await mySession.bytes(
+///         for: request,
+///         delegate: mySession.delegate as? URLSessionTaskDelegate
+///     )
+///
+/// If you encounter other calls in the wild that do not invoke `urlSession:didReceiveChallenge:` on this class,
+/// please report them to me.
+final class AIProxyCertificatePinningDelegate: NSObject, URLSessionDelegate, URLSessionTaskDelegate {
+
+   func urlSession(
+      _ session: URLSession,
+      task: URLSessionTask,
+      didReceive challenge: URLAuthenticationChallenge
+   ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+      return self.answerChallenge(challenge)
+   }
+
+   func urlSession(
+      _ session: URLSession,
+      didReceive challenge: URLAuthenticationChallenge
+   ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+      return self.answerChallenge(challenge)
+   }
+
+   private func answerChallenge(
+      _ challenge: URLAuthenticationChallenge
+   ) -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+      guard let secTrust = challenge.protectionSpace.serverTrust else {
+         aiproxyLogger.error("Could not access the server's security space")
+         return (.cancelAuthenticationChallenge, nil)
+      }
+
+      guard let certificate = getServerCert(secTrust: secTrust) else {
+         aiproxyLogger.error("Could not access the server's TLS cert")
+         return (.cancelAuthenticationChallenge, nil)
+      }
+
+      let serverPublicKey = SecCertificateCopyKey(certificate)!
+      let serverPublicKeyData = SecKeyCopyExternalRepresentation(serverPublicKey, nil)!
+
+      for publicKeyData in publicKeysAsData {
+         if serverPublicKeyData as Data == publicKeyData {
+            let credential = URLCredential(trust: secTrust)
+            return (.useCredential, credential)
+         }
+      }
+      return (.cancelAuthenticationChallenge, nil)
+   }
+}
+
+ // MARK: - Private
+ private var publicKeysAsData: [Data] = {
+     let newVal = publicKeysAsHex.map { publicKeyAsHex in
+         let keyData = Data(publicKeyAsHex)
+
+         let attributes: [String: Any] = [
+             kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+             kSecAttrKeyClass as String: kSecAttrKeyClassPublic,
+             kSecAttrKeySizeInBits as String: 256
+         ]
+
+         var error: Unmanaged<CFError>?
+         let publicKey = SecKeyCreateWithData(keyData as CFData, attributes as CFDictionary, &error)!
+
+         let localPublicKeyData = SecKeyCopyExternalRepresentation(publicKey, nil)! as Data
+
+         if let error = error {
+             print("Failed to create public key: \(error.takeRetainedValue() as Error)")
+             fatalError()
+         }
+         return localPublicKeyData
+     }
+     return newVal
+ }()
+
+private let publicKeysAsHex: [[UInt8]] = [
+     // live on api.aiproxy.pro
+     [
+         0x04, 0x25, 0xa2, 0xd1, 0x81, 0xc0, 0x38, 0xce, 0x57, 0xaa, 0x6e, 0xf0, 0x5a, 0xc3, 0x6a,
+         0xa7, 0xc4, 0x69, 0x69, 0xcb, 0xeb, 0x24, 0xe5, 0x20, 0x7d, 0x06, 0xcb, 0xc7, 0x49, 0xd5,
+         0x0c, 0xac, 0xe6, 0x96, 0xc5, 0xc9, 0x28, 0x00, 0x8e, 0x69, 0xff, 0x9d, 0x32, 0x01, 0x53,
+         0x74, 0xab, 0xfd, 0x46, 0x03, 0x32, 0xed, 0x93, 0x7f, 0x0f, 0xe9, 0xd9, 0xc3, 0xaf, 0xe7,
+         0xa5, 0xcb, 0xc1, 0x29, 0x35
+     ],
+
+     // live on beta-api.aiproxy.pro
+     [
+         0x04, 0xaf, 0xb2, 0xcc, 0xe2, 0x51, 0x92, 0xcf, 0xb8, 0x01, 0x25, 0xc1, 0xb8, 0xda, 0x29,
+         0x51, 0x9f, 0x91, 0x4c, 0xaa, 0x09, 0x66, 0x3d, 0x81, 0xd7, 0xad, 0x6f, 0xdb, 0x78, 0x10,
+         0xd4, 0xbe, 0xcd, 0x4f, 0xe3, 0xaf, 0x4f, 0xb6, 0xd2, 0xca, 0x85, 0xb6, 0xc7, 0x3e, 0xb4,
+         0x61, 0x62, 0xe1, 0xfc, 0x90, 0xd6, 0x84, 0x1f, 0x98, 0xca, 0x83, 0x60, 0x8b, 0x65, 0xcb,
+         0x1a, 0x57, 0x6e, 0x32, 0x35,
+     ],
+
+     // backup-EC-key-A.key
+     [
+         0x04, 0x2c, 0x25, 0x74, 0xbc, 0x7e, 0x18, 0x10, 0x27, 0xbd, 0x03, 0x56, 0x4a, 0x7b, 0x32,
+         0xd2, 0xc1, 0xb0, 0x2e, 0x58, 0x85, 0x9a, 0xb0, 0x7d, 0xcd, 0x7e, 0x23, 0x33, 0x88, 0x2f,
+         0xc0, 0xfe, 0xce, 0x2e, 0xbf, 0x36, 0x67, 0xc6, 0x81, 0xf6, 0x52, 0x2b, 0x9b, 0xaf, 0x97,
+         0x3c, 0xac, 0x00, 0x39, 0xd8, 0xcc, 0x43, 0x6b, 0x1d, 0x65, 0xa5, 0xad, 0xd1, 0x57, 0x4b,
+         0xad, 0xb1, 0x17, 0xd3, 0x10
+     ],
+
+     // backup-EC-key-B.key
+     [
+         0x04, 0x34, 0xae, 0x84, 0x94, 0xe9, 0x02, 0xf0, 0x78, 0x0e, 0xee, 0xe6, 0x4e, 0x39, 0x7f,
+         0xb4, 0x84, 0xf6, 0xec, 0x55, 0x20, 0x0d, 0x36, 0xe9, 0xa6, 0x44, 0x6b, 0x9b, 0xe1, 0xef,
+         0x19, 0xe7, 0x90, 0x5b, 0xf4, 0xa3, 0x29, 0xf3, 0x56, 0x7c, 0x60, 0x97, 0xf0, 0xc6, 0x61,
+         0x83, 0x31, 0x5d, 0x2d, 0xc9, 0xcc, 0x40, 0x43, 0xad, 0x81, 0x63, 0xfd, 0xcf, 0xe2, 0x8e,
+         0xfa, 0x07, 0x09, 0xf6, 0xf2
+     ],
+
+     // backup-EC-key-C.key
+     [
+         0x04, 0x84, 0x4e, 0x33, 0xc8, 0x60, 0xe7, 0x78, 0xaa, 0xa2, 0xb6, 0x0b, 0xcf, 0x7a, 0x52,
+         0x43, 0xd1, 0x6d, 0x58, 0xff, 0x17, 0xb8, 0xea, 0x8a, 0x39, 0x53, 0xfb, 0x8b, 0x66, 0x7d,
+         0x10, 0x39, 0x80, 0x2c, 0x8d, 0xc9, 0xc3, 0x34, 0x33, 0x98, 0x14, 0xeb, 0x88, 0x7b, 0xf5,
+         0x4d, 0x1f, 0x07, 0xae, 0x6a, 0x02, 0x6b, 0xf5, 0x9b, 0xa8, 0xc6, 0x55, 0x5c, 0x27, 0xcd,
+         0x1b, 0xc0, 0x27, 0x2d, 0x82
+     ]
+
+ ]
+
+private func getServerCert(secTrust: SecTrust) -> SecCertificate? {
+    if #available(macOS 12.0, iOS 15.0, *) {
+        guard let certs = SecTrustCopyCertificateChain(secTrust) as? [SecCertificate] else {
+            return nil
+        }
+        return certs[0]
+    } else {
+        return SecTrustGetCertificateAtIndex(secTrust, 0);
+    }
+}

--- a/Sources/Anthropic/AIProxy/AIProxyService.swift
+++ b/Sources/Anthropic/AIProxy/AIProxyService.swift
@@ -1,0 +1,104 @@
+//
+//  AIProxyService.swift
+//
+//
+//  Created by Lou Zell on 7/31/24.
+//
+
+import Foundation
+
+private let aiproxySecureDelegate = AIProxyCertificatePinningDelegate()
+
+
+struct AIProxyService: AnthropicService {
+
+   let session: URLSession
+   let decoder: JSONDecoder
+
+   /// Your partial key is provided during the integration process at dashboard.aiproxy.pro
+   /// Please see the [integration guide](https://www.aiproxy.pro/docs/integration-guide.html) for acquiring your partial key
+   private let partialKey: String
+
+   /// Your service URL is also provided during the integration process.
+   private let serviceURL: String
+
+   /// Optionally supply your own client IDs to annotate requests with in the AIProxy developer dashboard.
+   /// It is safe to leave this blank (most people do). If you leave it blank, AIProxy generates client IDs for you.
+   private let clientID: String?
+
+   /// Set this flag to TRUE if you need to print request events in DEBUG builds.
+   private let debugEnabled: Bool
+
+   /// Defaults to "2023-06-01"
+   private var apiVersion: String
+
+   private static let betaHeader = "max-tokens-3-5-sonnet-2024-07-15"
+
+   init(
+      partialKey: String,
+      serviceURL: String,
+      clientID: String? = nil,
+      apiVersion: String = "2023-06-01",
+      debugEnabled: Bool)
+   {
+      self.session = URLSession(
+         configuration: .default,
+         delegate: aiproxySecureDelegate,
+         delegateQueue: nil
+      )
+      let decoderWithSnakeCaseStrategy = JSONDecoder()
+      decoderWithSnakeCaseStrategy.keyDecodingStrategy = .convertFromSnakeCase
+      self.decoder = decoderWithSnakeCaseStrategy
+      self.partialKey = partialKey
+      self.serviceURL = serviceURL
+      self.clientID = clientID
+      self.apiVersion = apiVersion
+      self.debugEnabled = debugEnabled
+   }
+
+   // MARK: Message
+
+   func createMessage(
+      _ parameter: MessageParameter)
+      async throws -> MessageResponse
+   {
+      var localParameter = parameter
+      localParameter.stream = false
+      let request = try await AnthropicAPI(base: serviceURL, apiPath: .messages).request(aiproxyPartialKey: partialKey, clientID: clientID, version: apiVersion, method: .post, params: localParameter, beta: Self.betaHeader)
+      return try await fetch(type: MessageResponse.self, with: request, debugEnabled: debugEnabled)
+   }
+
+   func streamMessage(
+      _ parameter: MessageParameter)
+      async throws -> AsyncThrowingStream<MessageStreamResponse, Error>
+   {
+      var localParameter = parameter
+      localParameter.stream = true
+      let request = try await AnthropicAPI(base: serviceURL, apiPath: .messages).request(aiproxyPartialKey: partialKey, clientID: clientID, version: apiVersion, method: .post, params: localParameter, beta: Self.betaHeader)
+      return try await fetchStream(type: MessageStreamResponse.self, with: request, debugEnabled: debugEnabled)
+   }
+
+   // MARK: Text Completion
+
+   func createTextCompletion(
+      _ parameter: TextCompletionParameter)
+      async throws -> TextCompletionResponse
+   {
+      var localParameter = parameter
+      localParameter.stream = false
+      let request = try await AnthropicAPI(base: serviceURL, apiPath: .textCompletions).request(aiproxyPartialKey: partialKey, clientID: clientID, version: apiVersion, method: .post, params: localParameter)
+      return try await fetch(type: TextCompletionResponse.self, with: request, debugEnabled: debugEnabled)
+   }
+
+   func createStreamTextCompletion(
+      _ parameter: TextCompletionParameter)
+      async throws -> AsyncThrowingStream<TextCompletionStreamResponse, Error>
+   {
+      var localParameter = parameter
+      localParameter.stream = true
+      let request = try await AnthropicAPI(base: serviceURL, apiPath: .textCompletions).request(aiproxyPartialKey: partialKey, clientID: clientID, version: apiVersion, method: .post, params: localParameter)
+      return try await fetchStream(type: TextCompletionStreamResponse.self, with: request, debugEnabled: debugEnabled)
+   }
+}
+
+

--- a/Sources/Anthropic/AIProxy/Endpoint+AIProxy.swift
+++ b/Sources/Anthropic/AIProxy/Endpoint+AIProxy.swift
@@ -1,0 +1,186 @@
+//
+//  Endpoint+AIProxy.swift
+//
+//
+//  Created by Lou Zell on 3/26/24.
+//
+
+import Foundation
+import OSLog
+import DeviceCheck
+#if canImport(UIKit)
+    import UIKit
+#endif
+#if canImport(IOKit)
+    import IOKit
+#endif
+#if os(watchOS)
+import WatchKit
+#endif
+
+private let aiproxyLogger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "UnknownApp",
+                                   category: "SwiftAnthropic+AIProxy")
+
+private let deviceCheckWarning = """
+    AIProxy warning: DeviceCheck is not available on this device.
+
+    To use AIProxy on an iOS simulator, set an AIPROXY_DEVICE_CHECK_BYPASS environment variable.
+
+    See the AIProxy section of the README at https://github.com/jamesrochabrun/SwiftAnthropic for instructions.
+    """
+
+
+// MARK: Endpoint+AIProxy
+extension Endpoint {
+
+   func request(
+      aiproxyPartialKey: String,
+      clientID: String?,
+      version: String,
+      method: HTTPMethod,
+      params: Encodable? = nil,
+      beta: String? = nil,
+      queryItems: [URLQueryItem] = [])
+      async throws -> URLRequest
+   {
+      var request = URLRequest(url: urlComponents(queryItems: queryItems).url!)
+
+      request.addValue(aiproxyPartialKey, forHTTPHeaderField: "aiproxy-partial-key")
+      if let clientID = clientID ?? getClientID() {
+          request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
+      }
+      if let deviceCheckToken = await getDeviceCheckToken() {
+          request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
+      }
+#if DEBUG && targetEnvironment(simulator)
+      if let deviceCheckBypass = ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] {
+         request.addValue(deviceCheckBypass, forHTTPHeaderField: "aiproxy-devicecheck-bypass")
+      }
+#endif
+
+      request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+      request.addValue("\(version)", forHTTPHeaderField: "anthropic-version")
+      if let beta {
+         request.addValue("\(beta)", forHTTPHeaderField: "anthropic-beta")
+      }
+      request.httpMethod = method.rawValue
+      if let params {
+         let encoder = JSONEncoder()
+         encoder.keyEncodingStrategy = .convertToSnakeCase
+         request.httpBody = try encoder.encode(params)
+      }
+      return request
+   }
+}
+
+
+// MARK: Private Helpers
+
+/// Gets a device check token for use in your calls to aiproxy.
+/// The device token may be nil when targeting the iOS simulator.
+private func getDeviceCheckToken() async -> String? {
+    guard DCDevice.current.isSupported else {
+        if ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] == nil {
+            aiproxyLogger.warning("\(deviceCheckWarning, privacy: .public)")
+        }
+        return nil
+    }
+
+    do {
+        let data = try await DCDevice.current.generateToken()
+        return data.base64EncodedString()
+    } catch {
+        aiproxyLogger.error("Could not create DeviceCheck token. Are you using an explicit bundle identifier?")
+        return nil
+    }
+}
+
+/// Get a unique ID for this client
+private func getClientID() -> String? {
+#if os(watchOS)
+    return WKInterfaceDevice.current().identifierForVendor?.uuidString
+#elseif canImport(UIKit)
+    return UIDevice.current.identifierForVendor?.uuidString
+#elseif canImport(IOKit)
+    return getIdentifierFromIOKit()
+#else
+    return nil
+#endif
+}
+
+
+// MARK: IOKit conditional dependency
+/// These functions are used on macOS for creating a client identifier.
+/// Unfortunately, macOS does not have a straightforward helper like UIKit's `identifierForVendor`
+#if canImport(IOKit)
+private func getIdentifierFromIOKit() -> String? {
+    guard let macBytes = copy_mac_address() as? Data else {
+        return nil
+    }
+    let macHex = macBytes.map { String(format: "%02X", $0) }
+    return macHex.joined(separator: ":")
+}
+
+// This function is taken from the Apple sample code at:
+// https://developer.apple.com/documentation/appstorereceipts/validating_receipts_on_the_device#3744656
+private func io_service(named name: String, wantBuiltIn: Bool) -> io_service_t? {
+    let default_port = kIOMainPortDefault
+    var iterator = io_iterator_t()
+    defer {
+        if iterator != IO_OBJECT_NULL {
+            IOObjectRelease(iterator)
+        }
+    }
+
+    guard let matchingDict = IOBSDNameMatching(default_port, 0, name),
+        IOServiceGetMatchingServices(default_port,
+                                     matchingDict as CFDictionary,
+                                     &iterator) == KERN_SUCCESS,
+        iterator != IO_OBJECT_NULL
+    else {
+        return nil
+    }
+
+    var candidate = IOIteratorNext(iterator)
+    while candidate != IO_OBJECT_NULL {
+        if let cftype = IORegistryEntryCreateCFProperty(candidate,
+                                                        "IOBuiltin" as CFString,
+                                                        kCFAllocatorDefault,
+                                                        0) {
+            let isBuiltIn = cftype.takeRetainedValue() as! CFBoolean
+            if wantBuiltIn == CFBooleanGetValue(isBuiltIn) {
+                return candidate
+            }
+        }
+
+        IOObjectRelease(candidate)
+        candidate = IOIteratorNext(iterator)
+    }
+
+    return nil
+}
+
+// This function is taken from the Apple sample code at:
+// https://developer.apple.com/documentation/appstorereceipts/validating_receipts_on_the_device#3744656
+private func copy_mac_address() -> CFData? {
+    // Prefer built-in network interfaces.
+    // For example, an external Ethernet adaptor can displace
+    // the built-in Wi-Fi as en0.
+    guard let service = io_service(named: "en0", wantBuiltIn: true)
+            ?? io_service(named: "en1", wantBuiltIn: true)
+            ?? io_service(named: "en0", wantBuiltIn: false)
+        else { return nil }
+    defer { IOObjectRelease(service) }
+
+    if let cftype = IORegistryEntrySearchCFProperty(
+        service,
+        kIOServicePlane,
+        "IOMACAddress" as CFString,
+        kCFAllocatorDefault,
+        IOOptionBits(kIORegistryIterateRecursively | kIORegistryIterateParents)) {
+            return (cftype as! CFData)
+    }
+
+    return nil
+}
+#endif

--- a/Sources/Anthropic/Private/Network/Endpoint.swift
+++ b/Sources/Anthropic/Private/Network/Endpoint.swift
@@ -27,12 +27,12 @@ protocol Endpoint {
 
 extension Endpoint {
 
-   private func urlComponents(
+   func urlComponents(
       queryItems: [URLQueryItem])
       -> URLComponents
    {
       var components = URLComponents(string: base)!
-      components.path = path
+      components.path = components.path.appending(path)
       if !queryItems.isEmpty {
          components.queryItems = queryItems
       }

--- a/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
+++ b/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
@@ -194,7 +194,7 @@ public struct MessageParameter: Encodable {
       public let name: String
       /// A description of what the function does, used by the model to choose when and how to call the function.
       public let description: String?
-      /// The parameters the functions accepts, described as a JSON Schema object. See the [guide](https://platform.openai.com/docs/guides/gpt/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema) for documentation about the format.
+      /// The parameters the functions accepts, described as a JSON Schema object. See the [guide](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema) for documentation about the format.
       /// To describe a function that accepts no parameters, provide the value `{"type": "object", "properties": {}}`.
       public let inputSchema: JSONSchema?
       

--- a/Sources/Anthropic/Service/AnthropicServiceFactory.swift
+++ b/Sources/Anthropic/Service/AnthropicServiceFactory.swift
@@ -25,7 +25,7 @@ public final class AnthropicServiceFactory {
       basePath: String = "https://api.anthropic.com",
       configuration: URLSessionConfiguration = .default,
       debugEnabled: Bool = false)
-      -> some AnthropicService
+      -> AnthropicService
    {
       DefaultAnthropicService(
          apiKey: apiKey,
@@ -34,4 +34,37 @@ public final class AnthropicServiceFactory {
          configuration: configuration,
          debugEnabled: debugEnabled)
    }
+
+   /// Creates and returns an instance of `AnthropicService`.
+   ///
+   /// - Parameters:
+   ///   - aiproxyPartialKey: The partial key provided in the 'API Keys' section of the AIProxy dashboard.
+   ///                        Please see the integration guide for acquiring your key, at https://www.aiproxy.pro/docs
+   ///
+   ///   - aiproxyServiceURL: The service URL is displayed in the AIProxy dashboard when you submit your Anthropic key.
+   ///
+   ///   - aiproxyClientID: If your app already has client or user IDs that you want to annotate AIProxy requests
+   ///                      with, you can pass a clientID here. If you do not have existing client or user IDs, leave
+   ///                      the `clientID` argument out, and IDs will be generated automatically for you.
+   ///
+   ///   - apiVersion: The Anthropic api version. Currently "2023-06-01". (Can be overriden)
+   ///   - debugEnabled: If `true` service prints event on DEBUG builds, default to `false`.
+   ///
+   /// - Returns: A conformer of `AnthropicService` that proxies all requests through api.aiproxy.pro
+   public static func service(
+      aiproxyPartialKey: String,
+      aiproxyServiceURL: String,
+      aiproxyClientID: String? = nil,
+      apiVersion: String = "2023-06-01",
+      debugEnabled: Bool = false)
+      -> AnthropicService
+   {
+      AIProxyService(
+         partialKey: aiproxyPartialKey,
+         serviceURL: aiproxyServiceURL,
+         clientID: aiproxyClientID,
+         apiVersion: apiVersion,
+         debugEnabled: debugEnabled)
+   }
+
 }


### PR DESCRIPTION
- Adds instructions for modifying integration code to route requests through AIProxy
- Adds the AIProxy public keys used for TLS handshake (cert pinning)
- Adds the headers and generating code for AIProxy client IDs and DeviceCheck
- Adds service selection screen to the example app:

<img src="https://github.com/user-attachments/assets/3d3a1730-8269-4acf-8dad-f8efc2bf5bc0" width=300>

