### PR TITLE
Make `MessageResponse.Content.ToolUse` `Codable`

### DIFF
--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
@@ -84,7 +84,7 @@ public struct MessageResponse: Decodable {
    public enum Content: Codable {
       public typealias Input = [String: DynamicContent]
       
-      public struct ToolUse: Decodable {
+      public struct ToolUse: Codable {
          public let id: String
          public let name: String
          public let input: [String: MessageResponse.Content.DynamicContent]


### PR DESCRIPTION
Tiny change I ended up implementing in a fork so that I could store things on device. `MessageResponse.Content.ToolUse` is already `Decodable` and the props are all `Codable`. 

Lmk if any feedback and awesome repo! 