### PR TITLE
adding optional `is_error` field to tool result

### DIFF
--- a/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
+++ b/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
@@ -183,13 +183,9 @@ public struct MessageParameter: Encodable {
                case isError = "is_error"
             }
                         
-            public static func toolResult(toolUseId: String, content: String) -> ContentObject {
+            public static func toolResult(_ toolUseId: String, _ content: String) -> ContentObject {
                 return .toolResult(toolUseId, content, nil)
-            }
-            
-            public static func toolResult(toolUseId: String, content: String, isError: Bool) -> ContentObject {
-                return .toolResult(toolUseId, content, isError)
-            }
+            }                     
          }
          
          public struct ImageSource: Encodable {

--- a/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
+++ b/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
@@ -157,9 +157,7 @@ public struct MessageParameter: Encodable {
                    try container.encode("tool_result", forKey: .type)
                    try container.encode(toolUseId, forKey: .toolUseId)
                    try container.encode(content, forKey: .content)
-                   if let isError = isError {
-                       try container.encode(isError, forKey: .isError)
-                   }
+                   try container.encodeIfPresent(isError, forKey: .isError)
                case .cache(let cache):
                    try container.encode(cache.type.rawValue, forKey: .type)
                    try container.encode(cache.text, forKey: .text)

--- a/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
+++ b/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
@@ -182,6 +182,14 @@ public struct MessageParameter: Encodable {
                case cacheControl = "cache_control"
                case isError = "is_error"
             }
+                        
+            public static func toolResult(toolUseId: String, content: String) -> ContentObject {
+                return .toolResult(toolUseId, content, nil)
+            }
+            
+            public static func toolResult(toolUseId: String, content: String, isError: Bool) -> ContentObject {
+                return .toolResult(toolUseId, content, isError)
+            }
          }
          
          public struct ImageSource: Encodable {

--- a/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
+++ b/Sources/Anthropic/Public/Parameters/Message/MessageParameter.swift
@@ -135,7 +135,7 @@ public struct MessageParameter: Encodable {
             case text(String)
             case image(ImageSource)
             case toolUse(String, String, MessageResponse.Content.Input)
-            case toolResult(String, String)
+            case toolResult(String, String, Bool?)
             case cache(Cache)
 
             // Custom encoding to handle different cases
@@ -153,10 +153,13 @@ public struct MessageParameter: Encodable {
                    try container.encode(id, forKey: .id)
                    try container.encode(name, forKey: .name)
                    try container.encode(input, forKey: .input)
-               case .toolResult(let toolUseId, let content):
+               case .toolResult(let toolUseId, let content, let isError):
                    try container.encode("tool_result", forKey: .type)
                    try container.encode(toolUseId, forKey: .toolUseId)
                    try container.encode(content, forKey: .content)
+                   if let isError = isError {
+                       try container.encode(isError, forKey: .isError)
+                   }
                case .cache(let cache):
                    try container.encode(cache.type.rawValue, forKey: .type)
                    try container.encode(cache.text, forKey: .text)
@@ -177,6 +180,7 @@ public struct MessageParameter: Encodable {
                case toolUseId = "tool_use_id"
                case content
                case cacheControl = "cache_control"
+               case isError = "is_error"
             }
          }
          


### PR DESCRIPTION
hey james — love this library, thanks for open sourcing it

adding the optional `is_error` field to the tool result, per the [anthropic docs](https://docs.anthropic.com/en/docs/build-with-claude/tool-use#handling-tool-use-and-tool-result-content-blocks).  I've found this to be pretty useful when working with claude 