### PR TITLE
Count Message tokens support

### DIFF
--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/ApiKeyIntroView.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/ApiKeyIntroView.swift
@@ -23,7 +23,7 @@ struct ApiKeyIntroView: View {
             .textFieldStyle(.roundedBorder)
             NavigationLink(destination: OptionsListView(service: AnthropicServiceFactory.service(
                apiKey: apiKey,
-               betaHeaders: ["prompt-caching-2024-07-31", "max-tokens-3-5-sonnet-2024-07-15"]))) {
+               betaHeaders: ["prompt-caching-2024-07-31", "max-tokens-3-5-sonnet-2024-07-15"], debugEnabled: true))) {
                Text("Continue")
                   .padding()
                   .padding(.horizontal, 48)

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/Messages/MessageDemoObservable.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/Messages/MessageDemoObservable.swift
@@ -17,6 +17,7 @@ import SwiftUI
    var errorMessage: String = ""
    var isLoading = false
    var selectedPDF: Data? = nil
+   var inputTokensCount: String?
    
    init(service: AnthropicService) {
       self.service = service
@@ -59,6 +60,11 @@ import SwiftUI
             self.errorMessage = "\(error)"
          }
       }
+   }
+   
+   func countTokens(parameters: MessageTokenCountParameter) async throws {
+      let inputTokens = try await service.countTokens(parameter: parameters)
+      inputTokensCount = "\(inputTokens.inputTokens)"
    }
    
    func analyzePDF(prompt: String, selectedSegment: MessageDemoView.ChatConfig) async throws {

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/Messages/MessageDemoView.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/Messages/MessageDemoView.swift
@@ -33,6 +33,9 @@ struct MessageDemoView: View {
             picker
             Text(observable.errorMessage)
                .foregroundColor(.red)
+            if let inputTokensCount = observable.inputTokensCount {
+               Text("Tokens: \(inputTokensCount)")
+            }
             messageView
          }
          .padding()
@@ -120,6 +123,10 @@ struct MessageDemoView: View {
                      messages: messages,
                      maxTokens: 1024
                   )
+                  
+                  // Input Tokens count
+                  let messageTokenCountParameter = MessageTokenCountParameter(model: .claude35Sonnet, messages: messages)
+                  try await observable.countTokens(parameters: messageTokenCountParameter)
                   
                   switch selectedSegment {
                   case .message:

--- a/README.md
+++ b/README.md
@@ -1211,6 +1211,50 @@ let parameters = MessageParameter(
 let response = try await service.createMessage(parameters)
 ```
 
+### Count Tokens
+
+Parameters:
+```swift
+public struct MessageTokenCountParameter: Encodable {
+    /// The model that will complete your prompt.
+    /// See [models](https://docs.anthropic.com/claude/reference/selecting-a-model) for additional details and options.
+    public let model: String
+    
+    /// Input messages.
+    /// Our models are trained to operate on alternating user and assistant conversational turns.
+    /// Each input message must be an object with a role and content.
+    public let messages: [MessageParameter.Message]
+    
+    /// System prompt.
+    /// A system prompt is a way of providing context and instructions to Claude.
+    /// System role can be either a simple String or an array of objects, use the objects array for prompt caching.
+    public let system: MessageParameter.System?
+    
+    /// Tools that can be used in the messages
+    public let tools: [MessageParameter.Tool]?
+}
+```
+
+Response:
+```swift
+public struct MessageInputTokens: Decodable {
+   
+   /// The total number of tokens across the provided list of messages, system prompt, and tools.
+   public let inputTokens: Int
+}
+```
+
+Usage:
+```swift
+let messageParameter = MessageParameter.Message(role: .user, content: .text("Hello, Claude"))
+let parameters = MessageTokenCountParameter(
+    model: .claude3Sonnet,
+    messages: [messageParameter]
+)
+let tokenCount = try await service.countTokens(parameter: parameters)
+print("Input tokens: \(tokenCount.inputTokens)")
+```
+
 ## AIProxy
 
 ### What is it?

--- a/Sources/Anthropic/AIProxy/AIProxyService.swift
+++ b/Sources/Anthropic/AIProxy/AIProxyService.swift
@@ -79,6 +79,14 @@ struct AIProxyService: AnthropicService {
       let request = try await AnthropicAPI(base: serviceURL, apiPath: .messages).request(aiproxyPartialKey: partialKey, clientID: clientID, version: apiVersion, method: .post, params: localParameter, betaHeaders: betaHeaders)
       return try await fetchStream(type: MessageStreamResponse.self, with: request, debugEnabled: debugEnabled)
    }
+   
+   func countTokens(
+      parameter: MessageTokenCountParameter)
+      async throws -> MessageInputTokens
+   {
+      let request = try await AnthropicAPI(base: serviceURL, apiPath: .countTokens).request(aiproxyPartialKey: partialKey, clientID: clientID, version: apiVersion, method: .post, params: parameter, betaHeaders: betaHeaders)
+      return try await fetch(type: MessageInputTokens.self, with: request, debugEnabled: debugEnabled)
+   }
 
    // MARK: Text Completion
 

--- a/Sources/Anthropic/Private/Network/AnthropicAPI.swift
+++ b/Sources/Anthropic/Private/Network/AnthropicAPI.swift
@@ -17,6 +17,7 @@ struct AnthropicAPI {
    enum APIPath {
       case messages
       case textCompletions
+      case countTokens
    }
 }
 
@@ -27,6 +28,7 @@ extension AnthropicAPI: Endpoint {
    var path: String {
       switch apiPath {
       case .messages: return "/v1/messages"
+      case .countTokens: return "/v1/messages/count_tokens"
       case .textCompletions: return "/v1/complete"
       }
    }

--- a/Sources/Anthropic/Public/Parameters/Message/MessageTokenCountParameter.swift
+++ b/Sources/Anthropic/Public/Parameters/Message/MessageTokenCountParameter.swift
@@ -1,0 +1,40 @@
+//
+//  MessageTokenCountParameter.swift
+//  SwiftAnthropic
+//
+//  Created by James Rochabrun on 1/3/25.
+//
+
+import Foundation
+
+public struct MessageTokenCountParameter: Encodable {
+   
+   /// The model that will complete your prompt.
+   /// See [models](https://docs.anthropic.com/claude/reference/selecting-a-model) for additional details and options.
+   public let model: String
+   
+   /// Input messages.
+   /// Our models are trained to operate on alternating user and assistant conversational turns.
+   /// Each input message must be an object with a role and content.
+   public let messages: [MessageParameter.Message]
+   
+   /// System prompt.
+   /// A system prompt is a way of providing context and instructions to Claude.
+   /// System role can be either a simple String or an array of objects, use the objects array for prompt caching.
+   public let system: MessageParameter.System?
+   
+   /// Tools that can be used in the messages
+   public let tools: [MessageParameter.Tool]?
+   
+   public init(
+      model: Model,
+      messages: [MessageParameter.Message],
+      system: MessageParameter.System? = nil,
+      tools: [MessageParameter.Tool]? = nil)
+   {
+      self.model = model.value
+      self.messages = messages
+      self.system = system
+      self.tools = tools
+   }
+}

--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageInputTokens.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageInputTokens.swift
@@ -1,0 +1,30 @@
+//
+//  MessageInputTokens.swift
+//  SwiftAnthropic
+//
+//  Created by James Rochabrun on 1/3/25.
+//
+
+import Foundation
+
+public struct MessageInputTokens: Decodable {
+   
+   /// The total number of tokens across the provided list of messages, system prompt, and tools.
+   public let inputTokens: Int
+   
+   public init(from decoder: Decoder) throws {
+      if let container = try? decoder.singleValueContainer(),
+         let dict = try? container.decode([String: Int].self),
+         let tokens = dict["input_tokens"] {
+         self.inputTokens = tokens
+      } else {
+         // Try regular JSON decoding as fallback
+         let container = try decoder.container(keyedBy: CodingKeys.self)
+         self.inputTokens = try container.decode(Int.self, forKey: .inputTokens)
+      }
+   }
+   
+   private enum CodingKeys: String, CodingKey {
+      case inputTokens = "input_tokens"
+   }
+}

--- a/Sources/Anthropic/Service/AnthropicService.swift
+++ b/Sources/Anthropic/Service/AnthropicService.swift
@@ -65,7 +65,7 @@ public protocol AnthropicService {
    /// For more information, refer to [Anthropic's Message API documentation](https://docs.anthropic.com/claude/reference/messages_post).
    func createMessage(
       _ parameter: MessageParameter)
-   async throws -> MessageResponse
+      async throws -> MessageResponse
    
    /// Creates a message stream with the provided parameters.
    ///
@@ -80,7 +80,38 @@ public protocol AnthropicService {
    /// For more information, refer to [Anthropic's Stream Message API documentation](https://docs.anthropic.com/claude/reference/messages-streaming).
    func streamMessage(
       _ parameter: MessageParameter)
-   async throws -> AsyncThrowingStream<MessageStreamResponse, Error>
+      async throws -> AsyncThrowingStream<MessageStreamResponse, Error>
+   
+   /// Counts the number of tokens that would be used by a message for a given model.
+   ///
+   /// - Parameters:
+   ///   - parameter: The parameters used to count tokens, including the model, messages, system prompt, and tools.
+   ///
+   /// - Returns: A `MessageInputTokens` object containing the count of input tokens.
+   ///
+   /// - Throws: An error if the token counting request fails.
+   ///
+   /// Example usage:
+   /// ```swift
+   /// let parameter = MessageTokenCountParameter(
+   ///     model: .claude3Sonnet,
+   ///     messages: [
+   ///         .init(
+   ///             role: .user,
+   ///             content: .text("Hello, Claude!")
+   ///         )
+   ///     ]
+   /// )
+   ///
+   /// let tokenCount = try await client.countTokens(parameter: parameter)
+   /// print("Input tokens: \(tokenCount.inputTokens)")
+   /// ```
+   ///
+   /// For more details, see [Count Message tokens](https://docs.anthropic.com/en/api/messages-count-tokens)
+   func countTokens(
+       parameter: MessageTokenCountParameter)
+      async throws -> MessageInputTokens
+
    
    // MARK: Text Completion
    
@@ -91,7 +122,7 @@ public protocol AnthropicService {
    /// For more information, refer to [Anthropic's Text Completion API documentation](https://docs.anthropic.com/claude/reference/complete_post).
    func createTextCompletion(
       _ parameter: TextCompletionParameter)
-   async throws -> TextCompletionResponse
+      async throws -> TextCompletionResponse
    
    /// - Parameter parameters: Parameters for the create stream text completion request.
    /// - Returns: A [TextCompletionResponse](https://docs.anthropic.com/claude/reference/streaming).
@@ -100,7 +131,7 @@ public protocol AnthropicService {
    /// For more information, refer to [Anthropic's Text Completion API documentation](https://docs.anthropic.com/claude/reference/streaming).
    func createStreamTextCompletion(
       _ parameter: TextCompletionParameter)
-   async throws -> AsyncThrowingStream<TextCompletionStreamResponse, Error>
+      async throws -> AsyncThrowingStream<TextCompletionStreamResponse, Error>
 }
 
 extension AnthropicService {

--- a/Sources/Anthropic/Service/DefaultAnthropicService.swift
+++ b/Sources/Anthropic/Service/DefaultAnthropicService.swift
@@ -59,6 +59,14 @@ struct DefaultAnthropicService: AnthropicService {
       return try await fetchStream(type: MessageStreamResponse.self, with: request, debugEnabled: debugEnabled)
    }
    
+   func countTokens(
+      parameter: MessageTokenCountParameter)
+      async throws -> MessageInputTokens
+   {
+      let request = try AnthropicAPI(base: basePath, apiPath: .countTokens).request(apiKey: apiKey, version: apiVersion, method: .post, params: parameter, betaHeaders: betaHeaders)
+      return try await fetch(type: MessageInputTokens.self, with: request, debugEnabled: debugEnabled)
+   }
+   
    /// "messages-2023-12-15"
    // MARK: Text Completion
 


### PR DESCRIPTION
https://docs.anthropic.com/en/api/messages-count-tokens

### Count Tokens

Parameters:
```swift
public struct MessageTokenCountParameter: Encodable {
    /// The model that will complete your prompt.
    /// See [models](https://docs.anthropic.com/claude/reference/selecting-a-model) for additional details and options.
    public let model: String

    /// Input messages.
    /// Our models are trained to operate on alternating user and assistant conversational turns.
    /// Each input message must be an object with a role and content.
    public let messages: [MessageParameter.Message]

    /// System prompt.
    /// A system prompt is a way of providing context and instructions to Claude.
    /// System role can be either a simple String or an array of objects, use the objects array for prompt caching.
    public let system: MessageParameter.System?

    /// Tools that can be used in the messages
    public let tools: [MessageParameter.Tool]?
}
```

Response:
```swift
public struct MessageInputTokens: Decodable {

   /// The total number of tokens across the provided list of messages, system prompt, and tools.
   public let inputTokens: Int
}
```

Usage:
```swift
let messageParameter = MessageParameter.Message(role: .user, content: .text("Hello, Claude"))
let parameters = MessageTokenCountParameter(
    model: .claude3Sonnet,
    messages: [messageParameter]
)
let tokenCount = try await service.countTokens(parameter: parameters)
print("Input tokens: \(tokenCount.inputTokens)")
```