### PR TITLE
Support For text editor Tool

### DIFF
--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample.xcodeproj/project.pbxproj
@@ -15,12 +15,12 @@
 		7B3287E42B8B1261002C7FEF /* SwiftAnthropicExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3287E32B8B1261002C7FEF /* SwiftAnthropicExampleTests.swift */; };
 		7B3287EE2B8B1261002C7FEF /* SwiftAnthropicExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3287ED2B8B1261002C7FEF /* SwiftAnthropicExampleUITests.swift */; };
 		7B3287F02B8B1261002C7FEF /* SwiftAnthropicExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3287EF2B8B1261002C7FEF /* SwiftAnthropicExampleUITestsLaunchTests.swift */; };
-		7B3288012B8B13AC002C7FEF /* SwiftAnthropic in Frameworks */ = {isa = PBXBuildFile; productRef = 7B3288002B8B13AC002C7FEF /* SwiftAnthropic */; };
 		7B3288042B8B14A3002C7FEF /* ApiKeyIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3288032B8B14A3002C7FEF /* ApiKeyIntroView.swift */; };
 		7B3288062B8B1530002C7FEF /* OptionsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3288052B8B1530002C7FEF /* OptionsListView.swift */; };
 		7B3288082B8B1750002C7FEF /* MessageDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3288072B8B1750002C7FEF /* MessageDemoView.swift */; };
 		7B32880A2B8B17A1002C7FEF /* MessageDemoObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3288092B8B17A1002C7FEF /* MessageDemoObservable.swift */; };
 		7B531D782B96FFFA0047DBAB /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B531D772B96FFFA0047DBAB /* PhotoPicker.swift */; };
+		7B73EA002D877D5900BF0CD1 /* SwiftAnthropic in Frameworks */ = {isa = PBXBuildFile; productRef = 7B73E9FF2D877D5900BF0CD1 /* SwiftAnthropic */; };
 		7BF304E02BBFBE1000671273 /* MessageFunctionCallingDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF304DE2BBFBE1000671273 /* MessageFunctionCallingDemoView.swift */; };
 		7BF304E12BBFBE1000671273 /* MessageFunctionCallingObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF304DF2BBFBE1000671273 /* MessageFunctionCallingObservable.swift */; };
 /* End PBXBuildFile section */
@@ -72,7 +72,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B3288012B8B13AC002C7FEF /* SwiftAnthropic in Frameworks */,
+				7B73EA002D877D5900BF0CD1 /* SwiftAnthropic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -194,7 +194,7 @@
 			);
 			name = SwiftAnthropicExample;
 			packageProductDependencies = (
-				7B3288002B8B13AC002C7FEF /* SwiftAnthropic */,
+				7B73E9FF2D877D5900BF0CD1 /* SwiftAnthropic */,
 			);
 			productName = SwiftAnthropicExample;
 			productReference = 7B3287CF2B8B1260002C7FEF /* SwiftAnthropicExample.app */;
@@ -269,7 +269,7 @@
 			);
 			mainGroup = 7B3287C62B8B1260002C7FEF;
 			packageReferences = (
-				7B3287FF2B8B13AC002C7FEF /* XCLocalSwiftPackageReference "../.." */,
+				7B73E9FE2D877D5900BF0CD1 /* XCLocalSwiftPackageReference "../../../SwiftAnthropic" */,
 			);
 			productRefGroup = 7B3287D02B8B1260002C7FEF /* Products */;
 			projectDirPath = "";
@@ -654,14 +654,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		7B3287FF2B8B13AC002C7FEF /* XCLocalSwiftPackageReference "../.." */ = {
+		7B73E9FE2D877D5900BF0CD1 /* XCLocalSwiftPackageReference "../../../SwiftAnthropic" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../..;
+			relativePath = ../../../SwiftAnthropic;
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		7B3288002B8B13AC002C7FEF /* SwiftAnthropic */ = {
+		7B73E9FF2D877D5900BF0CD1 /* SwiftAnthropic */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SwiftAnthropic;
 		};

--- a/Sources/Anthropic/Public/Parameters/Message/JSONSchema.swift
+++ b/Sources/Anthropic/Public/Parameters/Message/JSONSchema.swift
@@ -1,0 +1,163 @@
+//
+//  JSONSchema.swift
+//  SwiftAnthropic
+//
+//  Created by James Rochabrun on 3/16/25.
+//
+
+import Foundation
+
+public struct JSONSchema: Codable, Equatable {
+   
+   public let type: JSONType
+   public let properties: [String: Property]?
+   public let required: [String]?
+   public let pattern: String?
+   public let const: String?
+   public let enumValues: [String]?
+   public let multipleOf: Int?
+   public let minimum: Int?
+   public let maximum: Int?
+   
+   private enum CodingKeys: String, CodingKey {
+      case type, properties, required, pattern, const
+      case enumValues = "enum"
+      case multipleOf, minimum, maximum
+   }
+   
+   public struct Property: Codable, Equatable {
+      
+      public let type: JSONType
+      public let description: String?
+      public let format: String?
+      public let items: Items?
+      public let required: [String]?
+      public let pattern: String?
+      public let const: String?
+      public let enumValues: [String]?
+      public let multipleOf: Int?
+      public let minimum: Double?
+      public let maximum: Double?
+      public let minItems: Int?
+      public let maxItems: Int?
+      public let uniqueItems: Bool?
+      
+      private enum CodingKeys: String, CodingKey {
+         case type, description, format, items, required, pattern, const
+         case enumValues = "enum"
+         case multipleOf, minimum, maximum
+         case minItems, maxItems, uniqueItems
+      }
+      
+      public init(
+         type: JSONType,
+         description: String? = nil,
+         format: String? = nil,
+         items: Items? = nil,
+         required: [String]? = nil,
+         pattern: String? = nil,
+         const: String? = nil,
+         enumValues: [String]? = nil,
+         multipleOf: Int? = nil,
+         minimum: Double? = nil,
+         maximum: Double? = nil,
+         minItems: Int? = nil,
+         maxItems: Int? = nil,
+         uniqueItems: Bool? = nil)
+      {
+         self.type = type
+         self.description = description
+         self.format = format
+         self.items = items
+         self.required = required
+         self.pattern = pattern
+         self.const = const
+         self.enumValues = enumValues
+         self.multipleOf = multipleOf
+         self.minimum = minimum
+         self.maximum = maximum
+         self.minItems = minItems
+         self.maxItems = maxItems
+         self.uniqueItems = uniqueItems
+      }
+   }
+   
+   public enum JSONType: String, Codable {
+      case integer = "integer"
+      case string = "string"
+      case boolean = "boolean"
+      case array = "array"
+      case object = "object"
+      case number = "number"
+      case `null` = "null"
+   }
+   
+   public struct Items: Codable, Equatable {
+      
+      public let type: JSONType
+      public let properties: [String: Property]?
+      public let pattern: String?
+      public let const: String?
+      public let enumValues: [String]?
+      public let multipleOf: Int?
+      public let minimum: Double?
+      public let maximum: Double?
+      public let minItems: Int?
+      public let maxItems: Int?
+      public let uniqueItems: Bool?
+      
+      private enum CodingKeys: String, CodingKey {
+         case type, properties, pattern, const
+         case enumValues = "enum"
+         case multipleOf, minimum, maximum, minItems, maxItems, uniqueItems
+      }
+      
+      public init(
+         type: JSONType,
+         properties: [String : Property]? = nil,
+         pattern: String? = nil,
+         const: String? = nil,
+         enumValues: [String]? = nil,
+         multipleOf: Int? = nil,
+         minimum: Double? = nil,
+         maximum: Double? = nil,
+         minItems: Int? = nil,
+         maxItems: Int? = nil,
+         uniqueItems: Bool? = nil)
+      {
+         self.type = type
+         self.properties = properties
+         self.pattern = pattern
+         self.const = const
+         self.enumValues = enumValues
+         self.multipleOf = multipleOf
+         self.minimum = minimum
+         self.maximum = maximum
+         self.minItems = minItems
+         self.maxItems = maxItems
+         self.uniqueItems = uniqueItems
+      }
+   }
+   
+   public init(
+      type: JSONType,
+      properties: [String : Property]? = nil,
+      required: [String]? = nil,
+      pattern: String? = nil,
+      const: String? = nil,
+      enumValues: [String]? = nil,
+      multipleOf: Int? = nil,
+      minimum: Int? = nil,
+      maximum: Int? = nil)
+   {
+      self.type = type
+      self.properties = properties
+      self.required = required
+      self.pattern = pattern
+      self.const = const
+      self.enumValues = enumValues
+      self.multipleOf = multipleOf
+      self.minimum = minimum
+      self.maximum = maximum
+   }
+}

--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
@@ -348,3 +348,61 @@ extension MessageResponse {
       }
    }
 }
+
+// MARK: MessageResponse.Content + DynamicContent
+
+public extension MessageResponse.Content.DynamicContent {
+   var stringValue: String? {
+      if case .string(let value) = self {
+         return value
+      }
+      return nil
+   }
+   
+   var intValue: Int? {
+      if case .integer(let value) = self {
+         return value
+      }
+      return nil
+   }
+   
+   var boolValue: Bool? {
+      if case .bool(let value) = self {
+         return value
+      }
+      return nil
+   }
+   
+   var arrayValue: [MessageResponse.Content.DynamicContent]? {
+      if case .array(let value) = self {
+         return value
+      }
+      return nil
+   }
+   
+   var dictionaryValue: [String: MessageResponse.Content.DynamicContent]? {
+      if case .dictionary(let value) = self {
+         return value
+      }
+      return nil
+   }
+}
+
+// MARK: MessageResponse.Content + TextEditorCommand
+
+public extension MessageResponse.Content {
+   
+   public enum TextEditorCommand: String {
+      case view
+      case str_replace
+      case insert
+      case create
+      case undo_edit
+      
+      // Helper to extract command from input
+      public static func from(_ input: [String: DynamicContent]) -> TextEditorCommand? {
+         guard let commandValue = input["command"]?.stringValue else { return nil }
+         return TextEditorCommand(rawValue: commandValue)
+      }
+   }
+}


### PR DESCRIPTION
[Documentation](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool)

<img width="691" alt="Screenshot 2025-03-16 at 9 04 03 PM" src="https://github.com/user-attachments/assets/4364cb10-f38c-41b1-ac35-edfeb11a488b" />

### MAJOR CHANGE ⚠️

This version makes a major change in how Tool are created, please update accordingly.

### Previous

Previously, the Tool was implemented as a struct that you initialized directly:

```swift
let weatherTool = MessageParameter.Tool(
    name: "get_weather", 
    description: "Get the current weather in a given location",
    inputSchema: .init(
        type: .object,
        properties: [
            "location": .init(type: .string, description: "The city and state, e.g. San Francisco, CA"),
            "unit": .init(type: .string, description: "The unit of temperature, either celsius or fahrenheit")
        ],
        required: ["location"]
    )
)
```

### Now

As of this update, Tool is now implemented as an enum with two cases:

- **function**: For standard function-based tools that have a schema

```swift
let weatherTool = MessageParameter.Tool.function(
    name: "get_weather", 
    description: "Get the current weather in a given location",
    inputSchema: .init(
        type: .object,
        properties: [
            "location": .init(type: .string, description: "The city and state, e.g. San Francisco, CA"),
            "unit": .init(type: .string, description: "The unit of temperature, either celsius or fahrenheit")
        ],
        required: ["location"]
    ),
    cacheControl: nil
)
```

- **hosted**: For Anthropic-hosted tools like the text editor

```swift
let textEditorTool = MessageParameter.Tool.hosted(
    type: "text_editor_20250124", 
    name: "str_replace_editor"
)
```

This change provides better type safety and a clearer distinction between different types of tools. All existing code using the previous struct-based approach will need to be updated to use the new enum-based approach.

### Text Editor Tool

Claude can use an Anthropic-defined text editor tool to view and modify text files, helping you debug, fix, and improve your code or other text documents. This allows Claude to directly interact with your files, providing hands-on assistance rather than just suggesting changes.

#### Compatible Models

The text editor tool is only available for specific Claude models:

- **Claude 3.7 Sonnet**: Use `text_editor_20250124`
- **Claude 3.5 Sonnet**: Use `text_editor_20241022`

Both versions provide identical capabilities - the version you use should match the model you're working with.

#### Use Cases

Some examples of when to use the text editor tool are:

- **Code debugging**: Have Claude identify and fix bugs in your code, from syntax errors to logic issues
- **Code refactoring**: Let Claude improve your code structure, readability, and performance
- **Documentation generation**: Ask Claude to add docstrings, comments, or README files
- **Test creation**: Have Claude create unit tests for your code

#### Using the Text Editor Tool

Here's how to provide the text editor tool to Claude:

```swift
// Create a message asking Claude to help with code
let messageParameter = MessageParameter.Message(role: .user, content: .text("There's a syntax error in my primes.py file. Can you help fix it?"))

// Define the text editor tool using the hosted tool type
let textEditorTool = MessageParameter.Tool.hosted(
    type: "text_editor_20250124", // Use the appropriate version for your model
    name: "str_replace_editor"
)

// Create parameters including the tool
let parameters = MessageParameter(
    model: .claude37Sonnet, 
    messages: [messageParameter], 
    maxTokens: 1024,
    tools: [textEditorTool]
)

// Create message or stream
let message = try await service.createMessage(parameters)

// Process Claude's response
for content in message.content {
    if case .toolUse(let id, let name, let input) = content {
        // Handle Claude's tool use request
        if let command = input["command"]?.stringValue {
            switch command {
            case "view":
                // Handle view file request
                // Read file and return contents to Claude
            case "str_replace":
                // Handle text replacement request
                // Replace text in file
            case "create":
                // Handle file creation request
                // Create new file
            case "insert":
                // Handle text insertion request
                // Insert text at specific location
            case "undo_edit":
                // Handle undo request
                // Revert last edit
            default:
                break
            }
        }
    }
}
```

#### Available Commands

The text editor tool supports several commands for viewing and modifying files:

1. **view**: Examine the contents of a file
   - Parameters: `path` (file path), `view_range` (optional line range)

2. **str_replace**: Replace specific text in a file
   - Parameters: `path` (file path), `old_str` (text to replace), `new_str` (replacement text)

3. **create**: Create a new file with specified content
   - Parameters: `path` (file path), `file_text` (content for the new file)

4. **insert**: Insert text at a specific location in a file
   - Parameters: `path` (file path), `insert_line` (line number), `new_str` (text to insert)

5. **undo_edit**: Revert the last edit made to a file
   - Parameters: `path` (file path)

For more information, see [[Anthropic's Text Editor Tool documentation](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool).

