### PR TITLE
Web search support

### DIFF
--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/FunctionCalling/MessageFunctionCallingDemoView.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/FunctionCalling/MessageFunctionCallingDemoView.swift
@@ -51,7 +51,7 @@ struct MessageFunctionCallingDemoView: View {
    var body: some View {
       ScrollView {
          VStack {
-            Text("TOOL: \(FunctionCallDefinition.getWeather.rawValue)")
+            Text("TOOL: Web search")
             picker
             Text(observable.errorMessage)
                .foregroundColor(.red)
@@ -94,11 +94,18 @@ struct MessageFunctionCallingDemoView: View {
                let messages = [MessageParameter.Message(role: .user, content: .list(finalInput))]
                
                prompt = ""
+               
+               let webSearchTool = MessageParameter.webSearch(
+                  maxUses: 5,
+                  allowedDomains: ["wikipedia.org"],
+                  userLocation: .sanFrancisco
+               )
+               
                let parameters = MessageParameter(
                   model: .claude35Sonnet,
                   messages: messages,
                   maxTokens: 1024, 
-                  tools: [FunctionCallDefinition.getWeather.tool])
+                  tools: [webSearchTool])
                switch selectedSegment {
                case .message:
                   try await observable.createMessage(parameters: parameters)

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/FunctionCalling/MessageFunctionCallingObservable.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/FunctionCalling/MessageFunctionCallingObservable.swift
@@ -43,6 +43,10 @@ import SwiftUI
                   toolUse = toolUSe
                case .thinking(let thinking):
                   self.thinking = thinking.thinking
+               case .serverToolUse(let serverToolUse):
+                  dump(serverToolUse)
+               case .webSearchToolResult(let webSearchTool):
+                  dump(webSearchTool)
                }
             }
          } catch {
@@ -60,7 +64,7 @@ import SwiftUI
             let stream = try await service.streamMessage(parameters)
             isLoading = false
             for try await result in stream {
-
+               
                let content = result.delta?.text ?? ""
                self.message += content
                
@@ -98,7 +102,7 @@ import SwiftUI
    // MARK: Private
    
    private var task: Task<Void, Never>? = nil
-
+   
 }
 
 extension MessageResponse.Content.ToolUse {

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ An open-source Swift package designed for effortless interaction with [Anthropic
 - [Message](#message)
    - [Function Calling](#function-calling)
       - [Text Editor Tool](#text-editor-tool)
+      - [Web Search Tool](#web-search)
    - [Prompt Caching](#prompt-caching)
 - [Message Stream](#message-stream)
 - [Vision](#vision)
@@ -982,7 +983,47 @@ For general guidance in Prompt Caching please visit the official [Anthropic Docu
 
 <span style="background-color: #D3D3D3">
 
-/// Copied from Anthropic [website](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#large-context-caching-example))
+/// Copied from Anthropic [website](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#large-context-caching-example)
+
+### Web Search Tool
+
+/// Copied from Anthropic [website](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool))
+
+The [web search tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool) gives Claude direct access to real-time web content, allowing it to answer questions with up-to-date information beyond its knowledge cutoff. Claude automatically cites sources from search results as part of its answer.
+
+Supported models
+
+Web search is available on:
+
+- Claude 3.7 Sonnet (claude-3-7-sonnet-20250219)
+- Claude 3.5 Sonnet (new) (claude-3-5-sonnet-latest)
+- Claude 3.5 Haiku (claude-3-5-haiku-latest)
+
+How web search works:
+
+When you add the web search tool to your API request:
+
+Claude decides when to search based on the prompt.
+The API executes the searches and provides Claude with the results. This process may repeat multiple times throughout a single request.
+At the end of its turn, Claude provides a final response with cited sources.
+
+Usage in SwiftAnthropic
+
+`SwiftAnthropic` provides convenience initializers for web search tools, you can use it like this:
+
+```swift
+let webSearchTool = MessageParameter.webSearch(
+   maxUses: 5,
+   allowedDomains: ["wikipedia.org"],
+   userLocation: .sanFrancisco
+)
+               
+let parameters = MessageParameter(
+model: .claude35Sonnet,
+messages: messages,
+maxTokens: 1024, 
+tools: [webSearchTool])
+```
 
 Prompt Caching is in beta
 

--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,71 @@ MessageParameter.Tool(
    cacheControl: .init(type: .ephemeral))
 ```
 
+Using Prompt Caching with Documents (New in 2025):
+
+```swift
+let maxTokens = 1024
+let prompt = "Please analyze this document"
+
+// Load PDF data
+let pdfData = // your PDF data
+let base64PDF = pdfData.base64EncodedString()
+
+// Create document source with cache control at the parent level
+let documentSource = try MessageParameter.Message.Content.DocumentSource.pdf(
+    base64Data: base64PDF,
+    title: "Large Research Document",
+    cacheControl: .init(type: .ephemeral) // Cache control now at parent document.source level
+)
+
+// Create message with document and prompt
+let message = MessageParameter.Message(
+    role: .user,
+    content: .list([
+        .document(documentSource),
+        .text(prompt)
+    ])
+)
+
+// Create parameters
+let parameters = MessageParameter(
+    model: .claude35Sonnet,
+    messages: [message],
+    maxTokens: maxTokens
+)
+
+// Send request
+let response = try await service.createMessage(parameters)
+```
+
+Using Prompt Caching with Tool Results (New in 2025):
+
+
+```swift
+// Create tool result with cache control at the parent level
+let toolResult = MessageParameter.Message.Content.ContentObject.toolResult(
+    "tool_123",
+    "Large dataset response that should be cached",
+    cacheControl: .init(type: .ephemeral) // Cache control now at parent tool_result level
+)
+
+let message = MessageParameter.Message(
+    role: .assistant,
+    content: .list([toolResult])
+)
+
+// Include in subsequent message
+let userMessage = MessageParameter.Message(
+    role: .user,
+    content: .text("Please analyze the data from the previous tool result")
+)
+
+let parameters = MessageParameter(
+    model: .claude35Sonnet,
+    messages: [message, userMessage],
+    maxTokens: 1024
+)
+```
 
 Swift Response
 ```swift

--- a/Sources/Anthropic/Public/Parameters/Message/MessageParameter+Web.swift
+++ b/Sources/Anthropic/Public/Parameters/Message/MessageParameter+Web.swift
@@ -1,0 +1,108 @@
+//
+//  MessageParameter+Web.swift
+//  SwiftAnthropic
+//
+//  Created by James Rochabrun on 5/12/25.
+//
+
+import Foundation
+
+public extension MessageParameter {
+   
+   /// Creates a web search tool with default configuration
+   static func webSearch(
+      name: String = "web_search",
+      maxUses: Int? = nil
+   ) -> Tool {
+      let parameters = WebSearchParameters(maxUses: maxUses)
+      return .webSearch(name: name, parameters: parameters)
+   }
+   
+   /// Creates a web search tool with domain filtering
+   static func webSearch(
+      name: String = "web_search",
+      maxUses: Int? = nil,
+      allowedDomains: [String]? = nil,
+      blockedDomains: [String]? = nil
+   ) -> Tool {
+      let parameters = WebSearchParameters(
+         maxUses: maxUses,
+         allowedDomains: allowedDomains,
+         blockedDomains: blockedDomains
+      )
+      return .webSearch(name: name, parameters: parameters)
+   }
+   
+   /// Creates a web search tool with user location for localized results
+   static func webSearch(
+      name: String = "web_search",
+      maxUses: Int? = nil,
+      userLocation: UserLocation
+   ) -> Tool {
+      let parameters = WebSearchParameters(
+         maxUses: maxUses,
+         userLocation: userLocation
+      )
+      return .webSearch(name: name, parameters: parameters)
+   }
+   
+   /// Creates a web search tool with full configuration
+   static func webSearch(
+      name: String = "web_search",
+      maxUses: Int? = nil,
+      allowedDomains: [String]? = nil,
+      blockedDomains: [String]? = nil,
+      userLocation: UserLocation? = nil
+   ) -> Tool {
+      let parameters = WebSearchParameters(
+         maxUses: maxUses,
+         allowedDomains: allowedDomains,
+         blockedDomains: blockedDomains,
+         userLocation: userLocation
+      )
+      return .webSearch(name: name, parameters: parameters)
+   }
+   
+   /// Creates a location for a US city
+   static func usCity(
+      city: String,
+      region: String,
+      timezone: String
+   ) -> UserLocation {
+      return UserLocation(
+         type: .approximate,
+         city: city,
+         region: region,
+         country: "US",
+         timezone: timezone
+      )
+   }
+}
+
+public extension MessageParameter.UserLocation {
+   
+   /// Common US locations
+   static let sanFrancisco = Self(
+      type: .approximate,
+      city: "San Francisco",
+      region: "California",
+      country: "US",
+      timezone: "America/Los_Angeles"
+   )
+   
+   static let newYork = Self(
+      type: .approximate,
+      city: "New York",
+      region: "New York",
+      country: "US",
+      timezone: "America/New_York"
+   )
+   
+   static let chicago = Self(
+      type: .approximate,
+      city: "Chicago",
+      region: "Illinois",
+      country: "US",
+      timezone: "America/Chicago"
+   )
+}

--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageStreamResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageStreamResponse.swift
@@ -33,7 +33,7 @@ public struct MessageStreamResponse: Decodable {
    
    /// Available in "content_block_delta", "message_delta" events.
    public let delta: Delta?
-    
+   
    /// Available in "message_delta" events.
    public let usage: MessageResponse.Usage?
    
@@ -43,8 +43,12 @@ public struct MessageStreamResponse: Decodable {
    
    public let error: Error?
    
+   /// Web search tool result
+   public let toolUseId: String?
+   
+   public let content: [WebSearchResult]?
+   
    public struct Delta: Decodable {
-      
       public let type: String?
       
       /// type = text
@@ -61,7 +65,7 @@ public struct MessageStreamResponse: Decodable {
       
       // type = citations_delta
       public let citation: MessageResponse.Citation?
-
+      
       public let stopReason: String?
       
       public let stopSequence: String?
@@ -84,7 +88,7 @@ public struct MessageStreamResponse: Decodable {
       // Citations for text type
       public let citations: [MessageResponse.Citation]?
       
-      /// `tool_use` type
+      /// `tool_use` and `server_tool_use` type
       public let input: [String: MessageResponse.Content.DynamicContent]?
       
       public let name: String?
@@ -118,6 +122,17 @@ public struct MessageStreamResponse: Decodable {
    }
 }
 
+// MARK: - Web Search Results
+
+public struct WebSearchResult: Decodable {
+   public let type: String?
+   public let url: String?
+   public let title: String?
+   public let encryptedContent: String?
+   public let pageAge: String?
+   public let errorCode: String?
+}
+
 extension MessageStreamResponse {
    
    /// Helper to check if the delta contains thinking content
@@ -138,5 +153,15 @@ extension MessageStreamResponse {
    /// Helper to check if the content block is a redacted thinking block
    public var isRedactedThinkingBlock: Bool {
       return contentBlock?.type == "redacted_thinking"
+   }
+   
+   /// Helper to check if this is a server tool use (web search)
+   public var isServerToolUse: Bool {
+      return contentBlock?.type == "server_tool_use"
+   }
+   
+   /// Helper to check if this is a web search tool result
+   public var isWebSearchToolResult: Bool {
+      return type == "web_search_tool_result"
    }
 }


### PR DESCRIPTION
### Web Search Tool

/// Copied from Anthropic [website](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool)

The [web search tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool) gives Claude direct access to real-time web content, allowing it to answer questions with up-to-date information beyond its knowledge cutoff. Claude automatically cites sources from search results as part of its answer.

Supported models

Web search is available on:

- Claude 3.7 Sonnet (claude-3-7-sonnet-20250219)
- Claude 3.5 Sonnet (new) (claude-3-5-sonnet-latest)
- Claude 3.5 Haiku (claude-3-5-haiku-latest)

How web search works:

When you add the web search tool to your API request:

Claude decides when to search based on the prompt.
The API executes the searches and provides Claude with the results. This process may repeat multiple times throughout a single request.
At the end of its turn, Claude provides a final response with cited sources.

Usage in SwiftAnthropic

`SwiftAnthropic` provides convenience initializers for web search tools, you can use it like this:

```swift
let webSearchTool = MessageParameter.webSearch(
   maxUses: 5,
   allowedDomains: ["wikipedia.org"],
   userLocation: .sanFrancisco
)
               
let parameters = MessageParameter(
model: .claude35Sonnet,
messages: messages,
maxTokens: 1024, 
tools: [webSearchTool])
```