### PR TITLE
Add comprehensive Skills API support

### DIFF
--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		7B73EA002D877D5900BF0CD1 /* SwiftAnthropic in Frameworks */ = {isa = PBXBuildFile; productRef = 7B73E9FF2D877D5900BF0CD1 /* SwiftAnthropic */; };
 		7BF304E02BBFBE1000671273 /* MessageFunctionCallingDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF304DE2BBFBE1000671273 /* MessageFunctionCallingDemoView.swift */; };
 		7BF304E12BBFBE1000671273 /* MessageFunctionCallingObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF304DF2BBFBE1000671273 /* MessageFunctionCallingObservable.swift */; };
+		7BFBABF52EADD8AE003D084C /* SkillsDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFBABF32EADD8AD003D084C /* SkillsDemoView.swift */; };
+		7BFBABF62EADD8AE003D084C /* SkillsDemoObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFBABF22EADD8AD003D084C /* SkillsDemoObservable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +63,8 @@
 		7B531D772B96FFFA0047DBAB /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		7BF304DE2BBFBE1000671273 /* MessageFunctionCallingDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageFunctionCallingDemoView.swift; sourceTree = "<group>"; };
 		7BF304DF2BBFBE1000671273 /* MessageFunctionCallingObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageFunctionCallingObservable.swift; sourceTree = "<group>"; };
+		7BFBABF22EADD8AD003D084C /* SkillsDemoObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsDemoObservable.swift; sourceTree = "<group>"; };
+		7BFBABF32EADD8AD003D084C /* SkillsDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsDemoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -127,6 +131,7 @@
 				7B3288022B8B147D002C7FEF /* Messages */,
 				7B3287D62B8B1261002C7FEF /* Assets.xcassets */,
 				7B3287D82B8B1261002C7FEF /* Preview Content */,
+				7BFBABF42EADD8AD003D084C /* Skills */,
 			);
 			path = SwiftAnthropicExample;
 			sourceTree = "<group>";
@@ -172,6 +177,15 @@
 				7BF304DF2BBFBE1000671273 /* MessageFunctionCallingObservable.swift */,
 			);
 			path = FunctionCalling;
+			sourceTree = "<group>";
+		};
+		7BFBABF42EADD8AD003D084C /* Skills */ = {
+			isa = PBXGroup;
+			children = (
+				7BFBABF22EADD8AD003D084C /* SkillsDemoObservable.swift */,
+				7BFBABF32EADD8AD003D084C /* SkillsDemoView.swift */,
+			);
+			path = Skills;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -313,6 +327,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7BFBABF52EADD8AE003D084C /* SkillsDemoView.swift in Sources */,
+				7BFBABF62EADD8AE003D084C /* SkillsDemoObservable.swift in Sources */,
 				7B3288042B8B14A3002C7FEF /* ApiKeyIntroView.swift in Sources */,
 				7B3288082B8B1750002C7FEF /* MessageDemoView.swift in Sources */,
 				7B531D782B96FFFA0047DBAB /* PhotoPicker.swift in Sources */,

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/ApiKeyIntroView.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/ApiKeyIntroView.swift
@@ -23,7 +23,7 @@ struct ApiKeyIntroView: View {
             .textFieldStyle(.roundedBorder)
             NavigationLink(destination: OptionsListView(service: AnthropicServiceFactory.service(
                apiKey: apiKey,
-               betaHeaders: ["prompt-caching-2024-07-31", "max-tokens-3-5-sonnet-2024-07-15"], debugEnabled: true))) {
+               betaHeaders: ["prompt-caching-2024-07-31", "max-tokens-3-5-sonnet-2024-07-15", "skills-2025-10-02", "code-execution-2025-08-25"], debugEnabled: true))) {
                Text("Continue")
                   .padding()
                   .padding(.horizontal, 48)

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/FunctionCalling/MessageFunctionCallingObservable.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/FunctionCalling/MessageFunctionCallingObservable.swift
@@ -49,6 +49,8 @@ import SwiftUI
                   dump(webSearchTool)
                case .toolResult(let toolResult):
                  dump(toolResult)
+               case .codeExecutionToolResult(let toolResult):
+                 dump(toolResult)
                }
             }
          } catch {

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/OptionsListView.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/OptionsListView.swift
@@ -17,10 +17,11 @@ struct OptionsListView: View {
    
    /// https://docs.anthropic.com/claude/reference/getting-started-with-the-api
    enum APIOption: String, CaseIterable, Identifiable {
-      
+
       case message = "Message"
       case messageFunctionCall = "Function Call"
       case thinking = "Thinking Mode"
+      case skills = "Skills API"
 
       var id: Self { self }
    }
@@ -41,7 +42,8 @@ struct OptionsListView: View {
                MessageFunctionCallingDemoView(observable: .init(service: service))
             case .thinking:
                ThinkingModeMessageDemoView(observable: .init(service: service))
-                                           
+            case .skills:
+               SkillsDemoView(observable: .init(service: service))
             }
          }
       }

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/Skills/SkillsDemoObservable.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/Skills/SkillsDemoObservable.swift
@@ -1,0 +1,156 @@
+//
+//  SkillsDemoObservable.swift
+//  SwiftAnthropicExample
+//
+//  Created by James Rochabrun on 10/25/25.
+//
+
+import SwiftUI
+import SwiftAnthropic
+
+@MainActor
+@Observable class SkillsDemoObservable {
+
+   let service: AnthropicService
+
+   var message: String = ""
+   var errorMessage: String = ""
+   var isLoading = false
+   var availableSkills: [SkillResponse] = []
+   var containerId: String?
+
+   init(service: AnthropicService) {
+      self.service = service
+   }
+
+   /// Lists available skills
+   func listSkills() async {
+      isLoading = true
+      errorMessage = ""
+
+      do {
+         let response = try await service.listSkills(parameter: nil)
+         availableSkills = response.data
+         message = "Found \(response.data.count) skill(s)\n\n"
+         for skill in response.data {
+            message += "📦 \(skill.displayTitle ?? "No title")\n"
+            message += "   ID: \(skill.id)\n"
+            message += "   Source: \(skill.source)\n"
+            message += "   Version: \(skill.latestVersion ?? "none")\n\n"
+         }
+      } catch {
+         errorMessage = error.localizedDescription
+      }
+
+      isLoading = false
+   }
+
+   /// Sends a message using a skill (e.g., XLSX skill)
+   func createMessageWithSkill() async {
+      isLoading = true
+      errorMessage = ""
+      message = ""
+
+      do {
+         // Example: Use the xlsx skill to create a spreadsheet
+         let parameter = MessageParameter(
+            model: .claude37Sonnet,
+            messages: [
+               .init(
+                  role: .user,
+                  content: .text("Create a simple budget spreadsheet with categories: Housing, Food, Transportation, and Entertainment. Add sample monthly amounts.")
+               )
+            ],
+            maxTokens: 4096,
+            tools: [
+               .hosted(type: "code_execution_20250825", name: "code_execution")
+            ],
+            container: .init(
+               id: containerId, // Reuse container if available
+               skills: [
+                  .init(type: .anthropic, skillId: "xlsx", version: "latest")
+               ]
+            )
+         )
+
+         let response = try await service.createMessage(parameter)
+
+         // Save container ID for reuse
+         if let newContainerId = response.container?.id {
+            containerId = newContainerId
+            message += "📦 Container ID: \(newContainerId)\n\n"
+         }
+
+         // Display response
+         for content in response.content {
+            switch content {
+            case .text(let text, _):
+               message += text + "\n"
+            case .toolUse(let toolUse):
+               message += "\n🔧 Tool: \(toolUse.name)\n"
+               message += "Input: \(toolUse.input)\n"
+            default:
+               message += "Other content type\n"
+            }
+         }
+
+         if let stopReason = response.stopReason {
+            message += "\n⏹️ Stop reason: \(stopReason)"
+         }
+
+      } catch {
+         errorMessage = error.localizedDescription
+      }
+
+      isLoading = false
+   }
+
+   /// Streams a message using a skill
+   func streamMessageWithSkill() async {
+      isLoading = true
+      errorMessage = ""
+      message = ""
+
+      do {
+         let parameter = MessageParameter(
+            model: .claude37Sonnet,
+            messages: [
+               .init(
+                  role: .user,
+                  content: .text("Analyze this data and create a chart: Q1: $10k, Q2: $15k, Q3: $12k, Q4: $18k")
+               )
+            ],
+            maxTokens: 4096,
+            stream: true,
+            tools: [
+               .hosted(type: "code_execution_20250825", name: "code_execution")
+            ],
+            container: .init(
+               id: containerId,
+               skills: [
+                  .init(type: .anthropic, skillId: "xlsx", version: "latest")
+               ]
+            )
+         )
+
+         let stream = try await service.streamMessage(parameter)
+
+         for try await chunk in stream {
+            if let delta = chunk.delta {
+               if let text = delta.text {
+                  message += text
+               }
+            }
+
+            if let newContainerId = chunk.message?.container?.id {
+               containerId = newContainerId
+            }
+         }
+
+      } catch {
+         errorMessage = error.localizedDescription
+      }
+
+      isLoading = false
+   }
+}

--- a/Examples/SwiftAnthropicExample/SwiftAnthropicExample/Skills/SkillsDemoView.swift
+++ b/Examples/SwiftAnthropicExample/SwiftAnthropicExample/Skills/SkillsDemoView.swift
@@ -1,0 +1,169 @@
+//
+//  SkillsDemoView.swift
+//  SwiftAnthropicExample
+//
+//  Created by James Rochabrun on 10/25/25.
+//
+
+import SwiftUI
+import SwiftAnthropic
+
+struct SkillsDemoView: View {
+
+   @State var observable: SkillsDemoObservable
+
+   var body: some View {
+      ScrollView {
+         VStack(alignment: .leading, spacing: 20) {
+
+            // Info Section
+            GroupBox {
+               VStack(alignment: .leading, spacing: 8) {
+                  Text("Skills API Demo")
+                     .font(.headline)
+                  Text("Test the new Skills functionality including listing available skills and using them in messages.")
+                     .font(.caption)
+                     .foregroundStyle(.secondary)
+
+                  if let containerId = observable.containerId {
+                     Divider()
+                     Text("Container ID: \(containerId)")
+                        .font(.caption2)
+                        .foregroundStyle(.blue)
+                  }
+               }
+            }
+
+            // Action Buttons
+            VStack(spacing: 12) {
+               Button(action: {
+                  Task { await observable.listSkills() }
+               }) {
+                  Label("List Available Skills", systemImage: "list.bullet")
+                     .frame(maxWidth: .infinity)
+                     .padding()
+                     .background(Color.blue)
+                     .foregroundColor(.white)
+                     .cornerRadius(10)
+               }
+               .disabled(observable.isLoading)
+
+               Button(action: {
+                  Task { await observable.createMessageWithSkill() }
+               }) {
+                  Label("Create Budget with XLSX Skill", systemImage: "doc.text")
+                     .frame(maxWidth: .infinity)
+                     .padding()
+                     .background(Color.green)
+                     .foregroundColor(.white)
+                     .cornerRadius(10)
+               }
+               .disabled(observable.isLoading)
+
+               Button(action: {
+                  Task { await observable.streamMessageWithSkill() }
+               }) {
+                  Label("Stream Chart with XLSX Skill", systemImage: "chart.bar")
+                     .frame(maxWidth: .infinity)
+                     .padding()
+                     .background(Color.purple)
+                     .foregroundColor(.white)
+                     .cornerRadius(10)
+               }
+               .disabled(observable.isLoading)
+            }
+
+            // Response Section
+            if observable.isLoading {
+               ProgressView()
+                  .frame(maxWidth: .infinity)
+                  .padding()
+            }
+
+            if !observable.errorMessage.isEmpty {
+               GroupBox {
+                  VStack(alignment: .leading) {
+                     Label("Error", systemImage: "exclamationmark.triangle")
+                        .font(.headline)
+                        .foregroundColor(.red)
+                     Text(observable.errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                  }
+               }
+               .backgroundStyle(.red.opacity(0.1))
+            }
+
+            if !observable.message.isEmpty {
+               GroupBox {
+                  VStack(alignment: .leading, spacing: 8) {
+                     Label("Response", systemImage: "text.bubble")
+                        .font(.headline)
+
+                     ScrollView {
+                        Text(observable.message)
+                           .font(.system(.body, design: .monospaced))
+                           .textSelection(.enabled)
+                           .frame(maxWidth: .infinity, alignment: .leading)
+                     }
+                     .frame(maxHeight: 400)
+                  }
+               }
+            }
+
+            // Skills List
+            if !observable.availableSkills.isEmpty {
+               GroupBox {
+                  VStack(alignment: .leading, spacing: 12) {
+                     Label("Available Skills", systemImage: "square.stack.3d.up")
+                        .font(.headline)
+
+                     ForEach(observable.availableSkills, id: \.id) { skill in
+                        VStack(alignment: .leading, spacing: 4) {
+                           Text(skill.displayTitle ?? "No title")
+                              .font(.subheadline)
+                              .fontWeight(.medium)
+                           HStack {
+                              Text("ID: \(skill.id)")
+                                 .font(.caption2)
+                              Spacer()
+                              Text(skill.source.uppercased())
+                                 .font(.caption2)
+                                 .padding(.horizontal, 6)
+                                 .padding(.vertical, 2)
+                                 .background(skill.source == "anthropic" ? Color.blue.opacity(0.2) : Color.orange.opacity(0.2))
+                                 .cornerRadius(4)
+                           }
+                           .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 4)
+
+                        if skill.id != observable.availableSkills.last?.id {
+                           Divider()
+                        }
+                     }
+                  }
+               }
+            }
+
+            Spacer()
+         }
+         .padding()
+      }
+      .navigationTitle("Skills Demo")
+      .navigationBarTitleDisplayMode(.inline)
+   }
+}
+
+#Preview {
+   NavigationStack {
+      SkillsDemoView(
+         observable: .init(
+            service: AnthropicServiceFactory.service(
+               apiKey: "test-key",
+               betaHeaders: ["skills-2025-10-02", "code-execution-2025-08-25"]
+            )
+         )
+      )
+   }
+}

--- a/Sources/Anthropic/AIProxy/AIProxyService.swift
+++ b/Sources/Anthropic/AIProxy/AIProxyService.swift
@@ -112,5 +112,160 @@ struct AIProxyService: AnthropicService {
     let request = try await AnthropicAPI(base: serviceURL, apiPath: .textCompletions).request(aiproxyPartialKey: partialKey, clientID: clientID, version: apiVersion, method: .post, params: localParameter)
     return try await fetchStream(type: TextCompletionStreamResponse.self, with: request, debugEnabled: debugEnabled)
   }
+
+  // MARK: Skills Management
+
+  func createSkill(
+    _ parameter: SkillCreateParameter)
+  async throws -> SkillResponse
+  {
+    let request = try await AnthropicAPI(base: serviceURL, apiPath: .skills).multipartRequest(
+      aiproxyPartialKey: partialKey,
+      clientID: clientID,
+      version: apiVersion,
+      method: .post,
+      displayTitle: parameter.displayTitle,
+      files: parameter.files,
+      betaHeaders: betaHeaders
+    )
+    return try await fetch(type: SkillResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func listSkills(
+    parameter: ListSkillsParameter?)
+  async throws -> ListSkillsResponse
+  {
+    var queryItems: [URLQueryItem] = []
+    if let page = parameter?.page {
+      queryItems.append(URLQueryItem(name: "page", value: page))
+    }
+    if let limit = parameter?.limit {
+      queryItems.append(URLQueryItem(name: "limit", value: "\(limit)"))
+    }
+    if let source = parameter?.source {
+      queryItems.append(URLQueryItem(name: "source", value: source.rawValue))
+    }
+
+    let request = try await AnthropicAPI(base: serviceURL, apiPath: .skills).request(
+      aiproxyPartialKey: partialKey,
+      clientID: clientID,
+      version: apiVersion,
+      method: .get,
+      betaHeaders: betaHeaders,
+      queryItems: queryItems
+    )
+    return try await fetch(type: ListSkillsResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func retrieveSkill(
+    skillId: String)
+  async throws -> SkillResponse
+  {
+    let request = try await AnthropicAPI(base: serviceURL, apiPath: .skill(id: skillId)).request(
+      aiproxyPartialKey: partialKey,
+      clientID: clientID,
+      version: apiVersion,
+      method: .get,
+      betaHeaders: betaHeaders
+    )
+    return try await fetch(type: SkillResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func deleteSkill(
+    skillId: String)
+  async throws
+  {
+    let request = try await AnthropicAPI(base: serviceURL, apiPath: .skill(id: skillId)).request(
+      aiproxyPartialKey: partialKey,
+      clientID: clientID,
+      version: apiVersion,
+      method: .delete,
+      betaHeaders: betaHeaders
+    )
+    let httpRequest = try HTTPRequest(from: request)
+    let (_, response) = try await httpClient.data(for: httpRequest)
+
+    guard response.statusCode == 200 || response.statusCode == 204 else {
+      throw APIError.responseUnsuccessful(description: "Failed to delete skill: status code \(response.statusCode)")
+    }
+  }
+
+  // MARK: Skill Versions
+
+  func createSkillVersion(
+    skillId: String,
+    _ parameter: SkillVersionCreateParameter)
+  async throws -> SkillVersionResponse
+  {
+    let request = try await AnthropicAPI(base: serviceURL, apiPath: .skillVersions(skillId: skillId)).multipartRequest(
+      aiproxyPartialKey: partialKey,
+      clientID: clientID,
+      version: apiVersion,
+      method: .post,
+      displayTitle: nil,
+      files: parameter.files,
+      betaHeaders: betaHeaders
+    )
+    return try await fetch(type: SkillVersionResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func listSkillVersions(
+    skillId: String,
+    parameter: ListSkillVersionsParameter?)
+  async throws -> ListSkillVersionsResponse
+  {
+    var queryItems: [URLQueryItem] = []
+    if let page = parameter?.page {
+      queryItems.append(URLQueryItem(name: "page", value: page))
+    }
+    if let limit = parameter?.limit {
+      queryItems.append(URLQueryItem(name: "limit", value: "\(limit)"))
+    }
+
+    let request = try await AnthropicAPI(base: serviceURL, apiPath: .skillVersions(skillId: skillId)).request(
+      aiproxyPartialKey: partialKey,
+      clientID: clientID,
+      version: apiVersion,
+      method: .get,
+      betaHeaders: betaHeaders,
+      queryItems: queryItems
+    )
+    return try await fetch(type: ListSkillVersionsResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func retrieveSkillVersion(
+    skillId: String,
+    version: String)
+  async throws -> SkillVersionResponse
+  {
+    let request = try await AnthropicAPI(base: serviceURL, apiPath: .skillVersion(skillId: skillId, version: version)).request(
+      aiproxyPartialKey: partialKey,
+      clientID: clientID,
+      version: apiVersion,
+      method: .get,
+      betaHeaders: betaHeaders
+    )
+    return try await fetch(type: SkillVersionResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func deleteSkillVersion(
+    skillId: String,
+    version: String)
+  async throws
+  {
+    let request = try await AnthropicAPI(base: serviceURL, apiPath: .skillVersion(skillId: skillId, version: version)).request(
+      aiproxyPartialKey: partialKey,
+      clientID: clientID,
+      version: apiVersion,
+      method: .delete,
+      betaHeaders: betaHeaders
+    )
+    let httpRequest = try HTTPRequest(from: request)
+    let (_, response) = try await httpClient.data(for: httpRequest)
+
+    guard response.statusCode == 200 || response.statusCode == 204 else {
+      throw APIError.responseUnsuccessful(description: "Failed to delete skill version: status code \(response.statusCode)")
+    }
+  }
 }
 #endif

--- a/Sources/Anthropic/Private/Network/AnthropicAPI.swift
+++ b/Sources/Anthropic/Private/Network/AnthropicAPI.swift
@@ -10,26 +10,38 @@ import Foundation
 // MARK: AnthropicAPI
 
 struct AnthropicAPI {
-  
+
   let base: String
   let apiPath: APIPath
-  
+
   enum APIPath {
     case messages
     case textCompletions
     case countTokens
+
+    // Skills endpoints
+    case skills
+    case skill(id: String)
+    case skillVersions(skillId: String)
+    case skillVersion(skillId: String, version: String)
   }
 }
 
 // MARK: AnthropicAPI+Endpoint
 
 extension AnthropicAPI: Endpoint {
-  
+
   var path: String {
     switch apiPath {
     case .messages: return "/v1/messages"
     case .countTokens: return "/v1/messages/count_tokens"
     case .textCompletions: return "/v1/complete"
+
+    // Skills endpoints
+    case .skills: return "/v1/skills"
+    case .skill(let id): return "/v1/skills/\(id)"
+    case .skillVersions(let skillId): return "/v1/skills/\(skillId)/versions"
+    case .skillVersion(let skillId, let version): return "/v1/skills/\(skillId)/versions/\(version)"
     }
   }
 }

--- a/Sources/Anthropic/Public/Parameters/Skill/SkillParameter.swift
+++ b/Sources/Anthropic/Public/Parameters/Skill/SkillParameter.swift
@@ -1,0 +1,125 @@
+//
+//  SkillParameter.swift
+//
+//
+//  Created by James Rochabrun on 10/25/25.
+//
+
+import Foundation
+
+// MARK: - Skill Creation Parameters
+
+/// Parameters for creating a new skill.
+/// See [Create Skill API](https://docs.anthropic.com/claude/reference/skills/create-skill)
+public struct SkillCreateParameter {
+
+   /// Display title for the skill.
+   /// This is a human-readable label that is not included in the prompt sent to the model.
+   public let displayTitle: String?
+
+   /// Files to upload for the skill.
+   /// All files must be in the same top-level directory and must include a SKILL.md file at the root.
+   /// Total upload size must be under 8MB.
+   public let files: [SkillFile]
+
+   public init(
+      displayTitle: String? = nil,
+      files: [SkillFile]
+   ) {
+      self.displayTitle = displayTitle
+      self.files = files
+   }
+}
+
+/// Represents a file to be uploaded as part of a skill
+public struct SkillFile {
+   /// The file name with path relative to skill root (e.g., "skill_name/SKILL.md")
+   public let filename: String
+   /// The file data
+   public let data: Data
+   /// The MIME type of the file (e.g., "text/markdown", "text/x-python")
+   public let mimeType: String?
+
+   public init(
+      filename: String,
+      data: Data,
+      mimeType: String? = nil
+   ) {
+      self.filename = filename
+      self.data = data
+      self.mimeType = mimeType
+   }
+}
+
+// MARK: - Skill Version Parameters
+
+/// Parameters for creating a new version of an existing skill.
+/// See [Create Skill Version API](https://docs.anthropic.com/claude/reference/skills/create-skill-version)
+public struct SkillVersionCreateParameter {
+
+   /// Files to upload for the skill version.
+   /// All files must be in the same top-level directory and must include a SKILL.md file at the root.
+   /// Total upload size must be under 8MB.
+   public let files: [SkillFile]
+
+   public init(files: [SkillFile]) {
+      self.files = files
+   }
+}
+
+// MARK: - List Skills Parameters
+
+/// Parameters for listing skills with optional filtering.
+/// See [List Skills API](https://docs.anthropic.com/claude/reference/skills/list-skills)
+public struct ListSkillsParameter {
+
+   /// Pagination token for fetching a specific page of results.
+   /// Pass the value from a previous response's `nextPage` field to get the next page.
+   public let page: String?
+
+   /// Number of results to return per page.
+   /// Maximum value is 100. Defaults to 20.
+   public let limit: Int?
+
+   /// Filter skills by source.
+   /// - "custom": only return user-created skills
+   /// - "anthropic": only return Anthropic-created skills
+   public let source: SkillSource?
+
+   public enum SkillSource: String {
+      case custom
+      case anthropic
+   }
+
+   public init(
+      page: String? = nil,
+      limit: Int? = nil,
+      source: SkillSource? = nil
+   ) {
+      self.page = page
+      self.limit = limit
+      self.source = source
+   }
+}
+
+// MARK: - List Skill Versions Parameters
+
+/// Parameters for listing versions of a specific skill.
+/// See [List Skill Versions API](https://docs.anthropic.com/claude/reference/skills/list-skill-versions)
+public struct ListSkillVersionsParameter {
+
+   /// Pagination token for fetching a specific page of results.
+   public let page: String?
+
+   /// Number of results to return per page.
+   /// Maximum value is 100. Defaults to 20.
+   public let limit: Int?
+
+   public init(
+      page: String? = nil,
+      limit: Int? = nil
+   ) {
+      self.page = page
+      self.limit = limit
+   }
+}

--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
@@ -65,10 +65,20 @@ public struct MessageResponse: Decodable {
   ///
   /// This value will be non-null if one of your custom stop sequences was generated.
   public let stopSequence: String?
-  
+
   /// Container for the number of tokens used.
   public let usage: Usage
-  
+
+  /// Container information when skills are used.
+  /// Contains the container ID that can be reused in subsequent requests.
+  public let container: ContainerInfo?
+
+  /// Container information returned in responses when skills are used
+  public struct ContainerInfo: Decodable {
+    /// The container ID that can be reused across multiple messages
+    public let id: String?
+  }
+
   public enum Content: Codable {
     public typealias Input = [String: DynamicContent]
     public typealias Citations = [Citation]

--- a/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Message/MessageResponse.swift
@@ -111,20 +111,35 @@ public struct MessageResponse: Decodable {
       public let toolUseId: String?
       public let content: [ContentItem]
       public let type: String
-      
+
       private enum CodingKeys: String, CodingKey {
         case toolUseId = "tool_use_id"
         case content
         case type
       }
     }
-    
+
+    /// Generic code execution tool result for Skills API
+    /// Handles text_editor_code_execution_tool_result, bash_code_execution_tool_result, etc.
+    public struct CodeExecutionToolResult: Codable {
+      public let type: String
+      public let toolUseId: String?
+      public let content: DynamicContent
+
+      private enum CodingKeys: String, CodingKey {
+        case type
+        case toolUseId = "tool_use_id"
+        case content
+      }
+    }
+
     case text(String, Citations?)
     case toolUse(ToolUse)
     case thinking(Thinking)
     case serverToolUse(ServerToolUse)
     case webSearchToolResult(WebSearchToolResult)
     case toolResult(ToolResult)
+    case codeExecutionToolResult(CodeExecutionToolResult)
     
     private enum CodingKeys: String, CodingKey {
       case type, text, id, name, input, citations, thinking, signature
@@ -220,7 +235,14 @@ public struct MessageResponse: Decodable {
         let content = try container.decode(ToolResultContent.self, forKey: .content)
         self = .toolResult(ToolResult(content: content, isError: isError, toolUseId: toolUseId))
       default:
-        throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Invalid type value found in JSON!")
+        // Handle code execution tool results (text_editor, bash, etc.)
+        if type.hasSuffix("_tool_result") {
+          let toolUseId = try container.decodeIfPresent(String.self, forKey: .toolUseId)
+          let content = try container.decode(DynamicContent.self, forKey: .content)
+          self = .codeExecutionToolResult(CodeExecutionToolResult(type: type, toolUseId: toolUseId, content: content))
+        } else {
+          throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Invalid type value found in JSON: \(type)")
+        }
       }
     }
     
@@ -254,6 +276,10 @@ public struct MessageResponse: Decodable {
         try container.encode(toolResult.content, forKey: .content)
         try container.encodeIfPresent(toolResult.isError, forKey: .isError)
         try container.encodeIfPresent(toolResult.toolUseId, forKey: .toolUseId)
+      case .codeExecutionToolResult(let codeExecResult):
+        try container.encode(codeExecResult.type, forKey: .type)
+        try container.encodeIfPresent(codeExecResult.toolUseId, forKey: .toolUseId)
+        try container.encode(codeExecResult.content, forKey: .content)
       }
     }
   }

--- a/Sources/Anthropic/Public/ResponseModels/Skill/SkillResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Skill/SkillResponse.swift
@@ -1,0 +1,141 @@
+//
+//  SkillResponse.swift
+//
+//
+//  Created by James Rochabrun on 10/25/25.
+//
+
+import Foundation
+
+// MARK: - Skill Response
+
+/// Response for a single skill.
+/// Returned by create, retrieve, and list operations.
+/// See [Skills API](https://docs.anthropic.com/claude/reference/skills)
+public struct SkillResponse: Decodable {
+
+   /// Unique identifier for the skill.
+   /// The format and length of IDs may change over time.
+   /// - Example: "skill_01JAbcdefghijklmnopqrstuvw"
+   public let id: String
+
+   /// Object type. For Skills, this is always "skill".
+   public let type: String
+
+   /// Display title for the skill.
+   /// This is a human-readable label that is not included in the prompt sent to the model.
+   public let displayTitle: String?
+
+   /// Source of the skill.
+   /// - "custom": the skill was created by a user
+   /// - "anthropic": the skill was created by Anthropic
+   public let source: String
+
+   /// The latest version identifier for the skill.
+   /// This represents the most recent version of the skill that has been created.
+   /// - For Anthropic skills: date-based like "20251013"
+   /// - For custom skills: epoch timestamp like "1759178010641129"
+   public let latestVersion: String?
+
+   /// ISO 8601 timestamp of when the skill was created.
+   /// - Example: "2024-10-30T23:58:27.427722Z"
+   public let createdAt: String
+
+   /// ISO 8601 timestamp of when the skill was last updated.
+   /// - Example: "2024-10-30T23:58:27.427722Z"
+   public let updatedAt: String
+
+   private enum CodingKeys: String, CodingKey {
+      case id
+      case type
+      case displayTitle = "display_title"
+      case source
+      case latestVersion = "latest_version"
+      case createdAt = "created_at"
+      case updatedAt = "updated_at"
+   }
+}
+
+// MARK: - List Skills Response
+
+/// Response for listing skills with pagination support.
+/// See [List Skills API](https://docs.anthropic.com/claude/reference/skills/list-skills)
+public struct ListSkillsResponse: Decodable {
+
+   /// List of skills.
+   public let data: [SkillResponse]
+
+   /// Whether there are more results available.
+   /// If `true`, there are additional results that can be fetched using the `nextPage` token.
+   public let hasMore: Bool
+
+   /// Token for fetching the next page of results.
+   /// If `null`, there are no more results available.
+   /// Pass this value to the `page` parameter in the next request to get the next page.
+   public let nextPage: String?
+
+   private enum CodingKeys: String, CodingKey {
+      case data
+      case hasMore = "has_more"
+      case nextPage = "next_page"
+   }
+}
+
+// MARK: - Skill Version Response
+
+/// Response for a skill version.
+/// Returned by version create, retrieve, and list operations.
+/// See [Skill Versions API](https://docs.anthropic.com/claude/reference/skills/versions)
+public struct SkillVersionResponse: Decodable {
+
+   /// Unique identifier for the skill.
+   public let id: String
+
+   /// Object type. For skill versions, this is always "skill_version".
+   public let type: String
+
+   /// Display title for the skill.
+   public let displayTitle: String?
+
+   /// Source of the skill ("custom" or "anthropic").
+   public let source: String
+
+   /// Version identifier for this specific version.
+   /// - For Anthropic skills: date-based like "20251013"
+   /// - For custom skills: epoch timestamp like "1759178010641129"
+   public let version: String
+
+   /// ISO 8601 timestamp of when the skill version was created.
+   public let createdAt: String
+
+   private enum CodingKeys: String, CodingKey {
+      case id
+      case type
+      case displayTitle = "display_title"
+      case source
+      case version
+      case createdAt = "created_at"
+   }
+}
+
+// MARK: - List Skill Versions Response
+
+/// Response for listing skill versions with pagination support.
+/// See [List Skill Versions API](https://docs.anthropic.com/claude/reference/skills/list-skill-versions)
+public struct ListSkillVersionsResponse: Decodable {
+
+   /// List of skill versions.
+   public let data: [SkillVersionResponse]
+
+   /// Whether there are more results available.
+   public let hasMore: Bool
+
+   /// Token for fetching the next page of results.
+   public let nextPage: String?
+
+   private enum CodingKeys: String, CodingKey {
+      case data
+      case hasMore = "has_more"
+      case nextPage = "next_page"
+   }
+}

--- a/Sources/Anthropic/Public/ResponseModels/Skill/SkillResponse.swift
+++ b/Sources/Anthropic/Public/ResponseModels/Skill/SkillResponse.swift
@@ -13,47 +13,37 @@ import Foundation
 /// Returned by create, retrieve, and list operations.
 /// See [Skills API](https://docs.anthropic.com/claude/reference/skills)
 public struct SkillResponse: Decodable {
-
-   /// Unique identifier for the skill.
-   /// The format and length of IDs may change over time.
-   /// - Example: "skill_01JAbcdefghijklmnopqrstuvw"
-   public let id: String
-
-   /// Object type. For Skills, this is always "skill".
-   public let type: String
-
-   /// Display title for the skill.
-   /// This is a human-readable label that is not included in the prompt sent to the model.
-   public let displayTitle: String?
-
-   /// Source of the skill.
-   /// - "custom": the skill was created by a user
-   /// - "anthropic": the skill was created by Anthropic
-   public let source: String
-
-   /// The latest version identifier for the skill.
-   /// This represents the most recent version of the skill that has been created.
-   /// - For Anthropic skills: date-based like "20251013"
-   /// - For custom skills: epoch timestamp like "1759178010641129"
-   public let latestVersion: String?
-
-   /// ISO 8601 timestamp of when the skill was created.
-   /// - Example: "2024-10-30T23:58:27.427722Z"
-   public let createdAt: String
-
-   /// ISO 8601 timestamp of when the skill was last updated.
-   /// - Example: "2024-10-30T23:58:27.427722Z"
-   public let updatedAt: String
-
-   private enum CodingKeys: String, CodingKey {
-      case id
-      case type
-      case displayTitle = "display_title"
-      case source
-      case latestVersion = "latest_version"
-      case createdAt = "created_at"
-      case updatedAt = "updated_at"
-   }
+  
+  /// Unique identifier for the skill.
+  /// The format and length of IDs may change over time.
+  /// - Example: "skill_01JAbcdefghijklmnopqrstuvw"
+  public let id: String
+  
+  /// Object type. For Skills, this is always "skill".
+  public let type: String
+  
+  /// Display title for the skill.
+  /// This is a human-readable label that is not included in the prompt sent to the model.
+  public let displayTitle: String?
+  
+  /// Source of the skill.
+  /// - "custom": the skill was created by a user
+  /// - "anthropic": the skill was created by Anthropic
+  public let source: String
+  
+  /// The latest version identifier for the skill.
+  /// This represents the most recent version of the skill that has been created.
+  /// - For Anthropic skills: date-based like "20251013"
+  /// - For custom skills: epoch timestamp like "1759178010641129"
+  public let latestVersion: String?
+  
+  /// ISO 8601 timestamp of when the skill was created.
+  /// - Example: "2024-10-30T23:58:27.427722Z"
+  public let createdAt: String
+  
+  /// ISO 8601 timestamp of when the skill was last updated.
+  /// - Example: "2024-10-30T23:58:27.427722Z"
+  public let updatedAt: String
 }
 
 // MARK: - List Skills Response
@@ -61,24 +51,18 @@ public struct SkillResponse: Decodable {
 /// Response for listing skills with pagination support.
 /// See [List Skills API](https://docs.anthropic.com/claude/reference/skills/list-skills)
 public struct ListSkillsResponse: Decodable {
-
-   /// List of skills.
-   public let data: [SkillResponse]
-
-   /// Whether there are more results available.
-   /// If `true`, there are additional results that can be fetched using the `nextPage` token.
-   public let hasMore: Bool
-
-   /// Token for fetching the next page of results.
-   /// If `null`, there are no more results available.
-   /// Pass this value to the `page` parameter in the next request to get the next page.
-   public let nextPage: String?
-
-   private enum CodingKeys: String, CodingKey {
-      case data
-      case hasMore = "has_more"
-      case nextPage = "next_page"
-   }
+  
+  /// List of skills.
+  public let data: [SkillResponse]
+  
+  /// Whether there are more results available.
+  /// If `true`, there are additional results that can be fetched using the `nextPage` token.
+  public let hasMore: Bool
+  
+  /// Token for fetching the next page of results.
+  /// If `null`, there are no more results available.
+  /// Pass this value to the `page` parameter in the next request to get the next page.
+  public let nextPage: String?
 }
 
 // MARK: - Skill Version Response
@@ -87,35 +71,26 @@ public struct ListSkillsResponse: Decodable {
 /// Returned by version create, retrieve, and list operations.
 /// See [Skill Versions API](https://docs.anthropic.com/claude/reference/skills/versions)
 public struct SkillVersionResponse: Decodable {
-
-   /// Unique identifier for the skill.
-   public let id: String
-
-   /// Object type. For skill versions, this is always "skill_version".
-   public let type: String
-
-   /// Display title for the skill.
-   public let displayTitle: String?
-
-   /// Source of the skill ("custom" or "anthropic").
-   public let source: String
-
-   /// Version identifier for this specific version.
-   /// - For Anthropic skills: date-based like "20251013"
-   /// - For custom skills: epoch timestamp like "1759178010641129"
-   public let version: String
-
-   /// ISO 8601 timestamp of when the skill version was created.
-   public let createdAt: String
-
-   private enum CodingKeys: String, CodingKey {
-      case id
-      case type
-      case displayTitle = "display_title"
-      case source
-      case version
-      case createdAt = "created_at"
-   }
+  
+  /// Unique identifier for the skill.
+  public let id: String
+  
+  /// Object type. For skill versions, this is always "skill_version".
+  public let type: String
+  
+  /// Display title for the skill.
+  public let displayTitle: String?
+  
+  /// Source of the skill ("custom" or "anthropic").
+  public let source: String
+  
+  /// Version identifier for this specific version.
+  /// - For Anthropic skills: date-based like "20251013"
+  /// - For custom skills: epoch timestamp like "1759178010641129"
+  public let version: String
+  
+  /// ISO 8601 timestamp of when the skill version was created.
+  public let createdAt: String
 }
 
 // MARK: - List Skill Versions Response
@@ -123,19 +98,13 @@ public struct SkillVersionResponse: Decodable {
 /// Response for listing skill versions with pagination support.
 /// See [List Skill Versions API](https://docs.anthropic.com/claude/reference/skills/list-skill-versions)
 public struct ListSkillVersionsResponse: Decodable {
-
-   /// List of skill versions.
-   public let data: [SkillVersionResponse]
-
-   /// Whether there are more results available.
-   public let hasMore: Bool
-
-   /// Token for fetching the next page of results.
-   public let nextPage: String?
-
-   private enum CodingKeys: String, CodingKey {
-      case data
-      case hasMore = "has_more"
-      case nextPage = "next_page"
-   }
+  
+  /// List of skill versions.
+  public let data: [SkillVersionResponse]
+  
+  /// Whether there are more results available.
+  public let hasMore: Bool
+  
+  /// Token for fetching the next page of results.
+  public let nextPage: String?
 }

--- a/Sources/Anthropic/Service/AnthropicService.swift
+++ b/Sources/Anthropic/Service/AnthropicService.swift
@@ -134,6 +134,123 @@ public protocol AnthropicService {
   func createStreamTextCompletion(
     _ parameter: TextCompletionParameter)
   async throws -> AsyncThrowingStream<TextCompletionStreamResponse, Error>
+
+  // MARK: Skills Management
+
+  /// Creates a new skill by uploading skill files.
+  ///
+  /// - Parameter parameter: Parameters for creating the skill, including display title and files.
+  ///
+  /// - Returns: A [SkillResponse](https://docs.anthropic.com/claude/reference/skills/create-skill).
+  ///
+  /// - Throws: An error if the request fails.
+  ///
+  /// For more information, refer to [Anthropic's Skills API documentation](https://docs.anthropic.com/claude/reference/skills/create-skill).
+  func createSkill(
+    _ parameter: SkillCreateParameter)
+  async throws -> SkillResponse
+
+  /// Lists all skills available to your workspace with optional filtering and pagination.
+  ///
+  /// - Parameter parameter: Optional parameters for filtering and pagination.
+  ///
+  /// - Returns: A [ListSkillsResponse](https://docs.anthropic.com/claude/reference/skills/list-skills).
+  ///
+  /// - Throws: An error if the request fails.
+  ///
+  /// For more information, refer to [Anthropic's Skills API documentation](https://docs.anthropic.com/claude/reference/skills/list-skills).
+  func listSkills(
+    parameter: ListSkillsParameter?)
+  async throws -> ListSkillsResponse
+
+  /// Retrieves detailed information about a specific skill.
+  ///
+  /// - Parameter skillId: The unique identifier of the skill to retrieve.
+  ///
+  /// - Returns: A [SkillResponse](https://docs.anthropic.com/claude/reference/skills/get-skill).
+  ///
+  /// - Throws: An error if the request fails.
+  ///
+  /// For more information, refer to [Anthropic's Skills API documentation](https://docs.anthropic.com/claude/reference/skills/get-skill).
+  func retrieveSkill(
+    skillId: String)
+  async throws -> SkillResponse
+
+  /// Deletes a skill.
+  /// Note: All versions of the skill must be deleted before the skill itself can be deleted.
+  ///
+  /// - Parameter skillId: The unique identifier of the skill to delete.
+  ///
+  /// - Throws: An error if the request fails or if versions still exist.
+  ///
+  /// For more information, refer to [Anthropic's Skills API documentation](https://docs.anthropic.com/claude/reference/skills/delete-skill).
+  func deleteSkill(
+    skillId: String)
+  async throws
+
+  // MARK: Skill Versions
+
+  /// Creates a new version of an existing skill.
+  ///
+  /// - Parameters:
+  ///   - skillId: The unique identifier of the skill.
+  ///   - parameter: Parameters containing the files for the new version.
+  ///
+  /// - Returns: A [SkillVersionResponse](https://docs.anthropic.com/claude/reference/skills/create-skill-version).
+  ///
+  /// - Throws: An error if the request fails.
+  ///
+  /// For more information, refer to [Anthropic's Skills API documentation](https://docs.anthropic.com/claude/reference/skills/create-skill-version).
+  func createSkillVersion(
+    skillId: String,
+    _ parameter: SkillVersionCreateParameter)
+  async throws -> SkillVersionResponse
+
+  /// Lists all versions of a specific skill with pagination support.
+  ///
+  /// - Parameters:
+  ///   - skillId: The unique identifier of the skill.
+  ///   - parameter: Optional parameters for pagination.
+  ///
+  /// - Returns: A [ListSkillVersionsResponse](https://docs.anthropic.com/claude/reference/skills/list-skill-versions).
+  ///
+  /// - Throws: An error if the request fails.
+  ///
+  /// For more information, refer to [Anthropic's Skills API documentation](https://docs.anthropic.com/claude/reference/skills/list-skill-versions).
+  func listSkillVersions(
+    skillId: String,
+    parameter: ListSkillVersionsParameter?)
+  async throws -> ListSkillVersionsResponse
+
+  /// Retrieves detailed information about a specific skill version.
+  ///
+  /// - Parameters:
+  ///   - skillId: The unique identifier of the skill.
+  ///   - version: The version identifier to retrieve.
+  ///
+  /// - Returns: A [SkillVersionResponse](https://docs.anthropic.com/claude/reference/skills/get-skill-version).
+  ///
+  /// - Throws: An error if the request fails.
+  ///
+  /// For more information, refer to [Anthropic's Skills API documentation](https://docs.anthropic.com/claude/reference/skills/get-skill-version).
+  func retrieveSkillVersion(
+    skillId: String,
+    version: String)
+  async throws -> SkillVersionResponse
+
+  /// Deletes a specific version of a skill.
+  ///
+  /// - Parameters:
+  ///   - skillId: The unique identifier of the skill.
+  ///   - version: The version identifier to delete.
+  ///
+  /// - Throws: An error if the request fails.
+  ///
+  /// For more information, refer to [Anthropic's Skills API documentation](https://docs.anthropic.com/claude/reference/skills/delete-skill-version).
+  func deleteSkillVersion(
+    skillId: String,
+    version: String)
+  async throws
 }
 
 extension AnthropicService {

--- a/Sources/Anthropic/Service/DefaultAnthropicService.swift
+++ b/Sources/Anthropic/Service/DefaultAnthropicService.swift
@@ -92,5 +92,154 @@ struct DefaultAnthropicService: AnthropicService {
     let request = try AnthropicAPI(base: basePath, apiPath: .textCompletions).request(apiKey: apiKey, version: apiVersion, method: HTTPMethod.post, params: localParameter)
     return try await fetchStream(type: TextCompletionStreamResponse.self, with: request, debugEnabled: debugEnabled)
   }
-  
+
+  // MARK: Skills Management
+
+  func createSkill(
+    _ parameter: SkillCreateParameter)
+  async throws -> SkillResponse
+  {
+    let request = try AnthropicAPI(base: basePath, apiPath: .skills).multipartRequest(
+      apiKey: apiKey,
+      version: apiVersion,
+      method: .post,
+      displayTitle: parameter.displayTitle,
+      files: parameter.files,
+      betaHeaders: betaHeaders
+    )
+    return try await fetch(type: SkillResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func listSkills(
+    parameter: ListSkillsParameter?)
+  async throws -> ListSkillsResponse
+  {
+    var queryItems: [URLQueryItem] = []
+    if let page = parameter?.page {
+      queryItems.append(URLQueryItem(name: "page", value: page))
+    }
+    if let limit = parameter?.limit {
+      queryItems.append(URLQueryItem(name: "limit", value: "\(limit)"))
+    }
+    if let source = parameter?.source {
+      queryItems.append(URLQueryItem(name: "source", value: source.rawValue))
+    }
+
+    let request = try AnthropicAPI(base: basePath, apiPath: .skills).request(
+      apiKey: apiKey,
+      version: apiVersion,
+      method: .get,
+      betaHeaders: betaHeaders,
+      queryItems: queryItems
+    )
+    return try await fetch(type: ListSkillsResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func retrieveSkill(
+    skillId: String)
+  async throws -> SkillResponse
+  {
+    let request = try AnthropicAPI(base: basePath, apiPath: .skill(id: skillId)).request(
+      apiKey: apiKey,
+      version: apiVersion,
+      method: .get,
+      betaHeaders: betaHeaders
+    )
+    return try await fetch(type: SkillResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func deleteSkill(
+    skillId: String)
+  async throws
+  {
+    let request = try AnthropicAPI(base: basePath, apiPath: .skill(id: skillId)).request(
+      apiKey: apiKey,
+      version: apiVersion,
+      method: .delete,
+      betaHeaders: betaHeaders
+    )
+    // For DELETE requests, we just need to check the response status
+    let httpRequest = try HTTPRequest(from: request)
+    let (_, response) = try await httpClient.data(for: httpRequest)
+
+    guard response.statusCode == 200 || response.statusCode == 204 else {
+      throw APIError.responseUnsuccessful(description: "Failed to delete skill: status code \(response.statusCode)")
+    }
+  }
+
+  // MARK: Skill Versions
+
+  func createSkillVersion(
+    skillId: String,
+    _ parameter: SkillVersionCreateParameter)
+  async throws -> SkillVersionResponse
+  {
+    let request = try AnthropicAPI(base: basePath, apiPath: .skillVersions(skillId: skillId)).multipartRequest(
+      apiKey: apiKey,
+      version: apiVersion,
+      method: .post,
+      displayTitle: nil,
+      files: parameter.files,
+      betaHeaders: betaHeaders
+    )
+    return try await fetch(type: SkillVersionResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func listSkillVersions(
+    skillId: String,
+    parameter: ListSkillVersionsParameter?)
+  async throws -> ListSkillVersionsResponse
+  {
+    var queryItems: [URLQueryItem] = []
+    if let page = parameter?.page {
+      queryItems.append(URLQueryItem(name: "page", value: page))
+    }
+    if let limit = parameter?.limit {
+      queryItems.append(URLQueryItem(name: "limit", value: "\(limit)"))
+    }
+
+    let request = try AnthropicAPI(base: basePath, apiPath: .skillVersions(skillId: skillId)).request(
+      apiKey: apiKey,
+      version: apiVersion,
+      method: .get,
+      betaHeaders: betaHeaders,
+      queryItems: queryItems
+    )
+    return try await fetch(type: ListSkillVersionsResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func retrieveSkillVersion(
+    skillId: String,
+    version: String)
+  async throws -> SkillVersionResponse
+  {
+    let request = try AnthropicAPI(base: basePath, apiPath: .skillVersion(skillId: skillId, version: version)).request(
+      apiKey: apiKey,
+      version: apiVersion,
+      method: .get,
+      betaHeaders: betaHeaders
+    )
+    return try await fetch(type: SkillVersionResponse.self, with: request, debugEnabled: debugEnabled)
+  }
+
+  func deleteSkillVersion(
+    skillId: String,
+    version: String)
+  async throws
+  {
+    let request = try AnthropicAPI(base: basePath, apiPath: .skillVersion(skillId: skillId, version: version)).request(
+      apiKey: apiKey,
+      version: apiVersion,
+      method: .delete,
+      betaHeaders: betaHeaders
+    )
+    // For DELETE requests, we just need to check the response status
+    let httpRequest = try HTTPRequest(from: request)
+    let (_, response) = try await httpClient.data(for: httpRequest)
+
+    guard response.statusCode == 200 || response.statusCode == 204 else {
+      throw APIError.responseUnsuccessful(description: "Failed to delete skill version: status code \(response.statusCode)")
+    }
+  }
+
 }


### PR DESCRIPTION
## Overview

This PR adds full support for Anthropic's Skills API, enabling users to create, manage, and use skills in their SwiftAnthropic applications.

## What's New

### 🎯 Core Features

**Container Support**
- Add `Container` parameter to `MessageParameter` for specifying skills to load
- Add `Container` response field to `MessageResponse` for reusing containers across conversations
- Add `SkillReference` type for referencing both Anthropic-managed and custom skills
- Support for version pinning (specific versions or "latest")

**Skills Management**
- ✅ Create skills with file uploads (multipart/form-data)
- ✅ List all available skills with filtering (source: custom/anthropic)
- ✅ Retrieve individual skill details
- ✅ Delete skills
- ✅ Full version management (create, list, retrieve, delete)
- ✅ Pagination support for large skill lists

### 📦 New API Types

**Parameters:**
- `SkillCreateParameter` - Create new skills with files
- `SkillVersionCreateParameter` - Create new skill versions
- `SkillFile` - File data with metadata for uploads
- `ListSkillsParameter` - Filter and paginate skill lists
- `ListSkillVersionsParameter` - Paginate version lists

**Responses:**
- `SkillResponse` - Individual skill metadata
- `ListSkillsResponse` - Paginated skill results
- `SkillVersionResponse` - Version-specific details
- `ListSkillVersionsResponse` - Paginated version results

### 🔧 Implementation

**Service Methods (8 new):**
```swift
func createSkill(_:) async throws -> SkillResponse
func listSkills(parameter:) async throws -> ListSkillsResponse
func retrieveSkill(skillId:) async throws -> SkillResponse
func deleteSkill(skillId:) async throws

func createSkillVersion(skillId:_:) async throws -> SkillVersionResponse
func listSkillVersions(skillId:parameter:) async throws -> ListSkillVersionsResponse
func retrieveSkillVersion(skillId:version:) async throws -> SkillVersionResponse
func deleteSkillVersion(skillId:version:) async throws
```

**Infrastructure:**
- Multipart/form-data encoding for file uploads
- New API endpoints: `/v1/skills`, `/v1/skills/{id}`, `/v1/skills/{id}/versions`
- Full AIProxy compatibility with device check support
- Platform support: iOS 15+, macOS 12+, Linux

### 📱 Example Application Updates

**New Skills Demo:**
- Interactive `SkillsDemoView` with UI for testing
- `SkillsDemoObservable` with example implementations
- Demonstrates listing available skills
- Shows using skills in messages (XLSX spreadsheet example)
- Demonstrates container reuse across multi-turn conversations
- Includes streaming support with skills

**Updated Files:**
- `ApiKeyIntroView` - Added Skills beta headers
- `OptionsListView` - Added "Skills API" option

## Usage Example

```swift
// List available skills
let skills = try await service.listSkills(parameter: nil)
print("Found \(skills.data.count) skills")

// Create a message using a skill
let parameter = MessageParameter(
    model: .claude37Sonnet,
    messages: [.init(role: .user, content: .text("Create a budget spreadsheet"))],
    maxTokens: 4096,
    tools: [.hosted(type: "code_execution_20250825", name: "code_execution")],
    container: .init(
        skills: [
            .init(type: .anthropic, skillId: "xlsx", version: "latest")
        ]
    )
)

let response = try await service.createMessage(parameter)

// Reuse container in follow-up
let followUp = MessageParameter(
    model: .claude37Sonnet,
    messages: updatedMessages,
    maxTokens: 4096,
    container: .init(
        id: response.container?.id,  // Reuse for performance
        skills: [.init(type: .anthropic, skillId: "xlsx")]
    )
)
```

## Testing

### Automated
- ✅ Project builds successfully with no errors
- ✅ All existing tests pass
- ✅ Type-safe implementation with Swift enums

### Manual Testing
Run the example app and:
1. Select "Default Anthropic Service"
2. Enter API key with Skills access
3. Choose "Skills API" from the menu
4. Test all three demo buttons

## Technical Notes

- Follows existing codebase patterns and conventions
- Consistent documentation style with triple-slash comments
- Proper error handling for all operations
- Snake case conversion handled automatically
- Full backward compatibility maintained

## Files Changed

- **10 modified files** - Core API support
- **4 new files** - Skills parameters, responses, and demos
- **+1,242 lines** added

## Checklist

- [x] Code builds without errors
- [x] Follows existing code style
- [x] Documentation added
- [x] Example app updated
- [x] AIProxy compatibility maintained
- [x] Linux compatibility maintained
