### PR TITLE
Fix Linux build: declare swift-nio as an explicit dependency for NIOFoundationCompat

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.2"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -25,6 +26,7 @@ let package = Package(
             name: "SwiftAnthropic",
             dependencies: [
                 .product(name: "AsyncHTTPClient", package: "async-http-client", condition: .when(platforms: [.linux])),
+                .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: [.linux])),
             ],
             path: "Sources/Anthropic"),
         .testTarget(


### PR DESCRIPTION
### Problem

Building a package that depends on SwiftAnthropic on Linux currently fails with:

```
AsyncHTTPClientAdapter.swift:12:8: error: no such module 'NIOFoundationCompat'
```

`AsyncHTTPClientAdapter.swift` imports `NIOFoundationCompat` to use `Data(buffer:)` for converting the `ByteBuffer` returned by `async-http-client` into Foundation's `Data`. However, `swift-nio` — the package that provides `NIOFoundationCompat` — is not declared as an explicit dependency in `Package.swift`.

`async-http-client` depends on `swift-nio` internally, but does not re-export `NIOFoundationCompat` as a product. Swift Package Manager does not guarantee that modules from transitive dependencies are importable, and in practice this build fails on Linux regardless of Swift version or runner environment.

### Fix

Add `swift-nio` as an explicit package dependency and add `NIOFoundationCompat` as a Linux-conditional target dependency — matching the pattern already used for `AsyncHTTPClient`.

The `from: "2.81.0"` lower bound matches the minimum `swift-nio` version already required by `async-http-client` `1.25.2+`, so this introduces no new version constraints in practice.

### Verification

Tested against a minimal Swift 6.2 CLI package depending on SwiftAnthropic, built on `ubuntu-latest` using the official `swift:latest` Docker container. The build fails on `main` and passes with this fix applied.